### PR TITLE
Fix string with operator prefix is lexed as operator bug

### DIFF
--- a/parse/lex.go
+++ b/parse/lex.go
@@ -298,9 +298,12 @@ func (l *lexer) tryLexOperator() bool {
 		if l.input[l.pos+1:l.pos+2] == "}" {
 			return false
 		}
-	} else if op == "in" || op == "is" {
-		// Avoid matching "include" or functions like "is_currently_on"
-		if l.input[l.pos+2:l.pos+3] != " " {
+	} else if isAlpha(op) {
+		// If operator is alphabetic (such as "in" or "is"),
+		// we avoid matching "include" or functions like "is_currently_on"
+		// For such operators to be valid, they need to have a space after.
+		lenOp := len(op)
+		if (l.pos+lenOp+1) <= len(l.input) && l.input[l.pos+lenOp:l.pos+lenOp+1] != " " {
 			return false
 		}
 	} else if op == delimTrimWhitespace {
@@ -312,6 +315,16 @@ func (l *lexer) tryLexOperator() bool {
 	l.pos += len(op)
 	l.emit(tokenOperator)
 
+	return true
+}
+
+// Check if a string only contains alphabetic characters
+func isAlpha(s string) bool {
+	for _, r := range s {
+		if !unicode.IsLetter(r) {
+			return false
+		}
+	}
 	return true
 }
 

--- a/parse/lex_test.go
+++ b/parse/lex_test.go
@@ -92,6 +92,15 @@ var lexTests = []lexTest{
 		tEOF,
 	}},
 
+	{"string with operator prefix", "{{ orange }}", []token{
+		tPrintOpen,
+		tSpace,
+		mkTok(tokenName, "orange"),
+		tSpace,
+		tPrintClose,
+		tEOF,
+	}},
+
 	{"power and multiply", "{{ 1 ** 10 * 5 }}", []token{
 		tPrintOpen,
 		tSpace,


### PR DESCRIPTION
Before Lexer would lex `{{orange}}` as operator "or" and name "ange", but it should be name "orange". This PR fixes the bug.