### PR TITLE
Add parent built-in function

### DIFF
--- a/example_parent_test.go
+++ b/example_parent_test.go
@@ -1,0 +1,36 @@
+package stick_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/tyler-sommer/stick"
+)
+
+// An example of macro definition and usage.
+//
+// This example uses a macro to list the values, also showing two
+// ways to import macros. Check the templates in the testdata folder
+// for more information.
+func ExampleEnv_Execute_parent() {
+	d, _ := os.Getwd()
+	env := stick.New(stick.NewFilesystemLoader(filepath.Join(d, "testdata")))
+
+	err := env.Execute("parent.txt.twig", os.Stdout, nil)
+	if err != nil {
+		fmt.Println(err)
+	}
+	// Output:
+	// This is a document.
+	//
+	// Not A title
+	//
+	// Testing parent()
+	//
+	// This is a test
+	//
+	// Another section
+	//
+	// Some extra information.
+}

--- a/testdata/parent.txt.twig
+++ b/testdata/parent.txt.twig
@@ -1,0 +1,17 @@
+{% extends 'base.txt.twig' %}
+
+{% use 'parts.txt.twig' %}
+
+{% block title %}Not {{ parent() }}{% endblock %}
+
+{% block intro %}Testing parent(){% endblock %}
+
+{% block body %}This is a test{% endblock %}
+
+{% block secondary_title %}{{ parent() }}{% endblock %}
+
+{% block secondary_body %}{{ parent() }}{% endblock %}
+
+{% block conclusion %}{% endblock %}
+
+{% block footer %}{% endblock %}


### PR DESCRIPTION
This fixes #17 and fixes #19, adding `parent()` as a built-in. This function will render the parent block contents from a child template, for both extends and use type inheritance.