### PR TITLE
Fix property access in parsing subexpressions

### DIFF
--- a/parse/parse_expr.go
+++ b/parse/parse_expr.go
@@ -37,15 +37,13 @@ func (t *Tree) parseOuterExpr(expr Expr) (Expr, error) {
 			}
 
 			if nt.value == "[" {
-				switch attr.(type) {
-				case *NameExpr, *StringExpr, *NumberExpr, *GroupExpr:
-					// valid
-				default:
-					return nil, newUnexpectedTokenError(nt)
+				ntt := t.peekNonSpace()
+				if ntt.tokenType != tokenArrayClose {
+					if attr, err = t.parseOuterExpr(attr); err != nil {
+						return nil, err
+					}
 				}
-
-				_, err := t.expect(tokenArrayClose)
-				if err != nil {
+				if _, err := t.expect(tokenArrayClose); err != nil {
 					return nil, err
 				}
 			} else {
@@ -119,30 +117,39 @@ func (t *Tree) parseOuterExpr(expr Expr) (Expr, error) {
 				return nil, err
 			}
 		} else {
-			right, err = t.parseInnerExpr()
+			right, err = t.parseExpr()
 			if err != nil {
 				return nil, err
 			}
+			if v, ok := right.(*BinaryExpr); ok {
+				nxop := binaryOperators[v.Op]
+				if nxop.precedence < op.precedence || (nxop.precedence == op.precedence && op.leftAssoc()) {
+					left := v.Left
+					res := NewBinaryExpr(expr, op.Operator(), left, expr.Start())
+					v.Left = res
+					return v, nil
+				}
+			}
 		}
-
-		ntt := t.nextNonSpace()
-		if ntt.tokenType == tokenOperator {
-			nxop, ok := binaryOperators[ntt.value]
-			if !ok {
-				return nil, newUnexpectedTokenError(ntt)
-			}
-			if nxop.precedence < op.precedence || (nxop.precedence == op.precedence && op.leftAssoc()) {
-				t.backup()
-				return t.parseOuterExpr(NewBinaryExpr(expr, op.Operator(), right, expr.Start()))
-			}
-			t.backup()
-			right, err = t.parseOuterExpr(right)
-			if err != nil {
-				return nil, err
-			}
-		} else {
-			t.backup()
-		}
+		//
+		// ntt := t.nextNonSpace()
+		// if ntt.tokenType == tokenOperator {
+		// 	nxop, ok := binaryOperators[ntt.value]
+		// 	if !ok {
+		// 		return nil, newUnexpectedTokenError(ntt)
+		// 	}
+		// 	if nxop.precedence < op.precedence || (nxop.precedence == op.precedence && op.leftAssoc()) {
+		// 		t.backup()
+		// 		return t.parseOuterExpr(NewBinaryExpr(expr, op.Operator(), right, expr.Start()))
+		// 	}
+		// 	t.backup()
+		// 	right, err = t.parseOuterExpr(right)
+		// 	if err != nil {
+		// 		return nil, err
+		// 	}
+		// } else {
+		// 	t.backup()
+		// }
 		return NewBinaryExpr(expr, op.Operator(), right, expr.Start()), nil
 
 	default:

--- a/parse/parse_expr.go
+++ b/parse/parse_expr.go
@@ -131,25 +131,6 @@ func (t *Tree) parseOuterExpr(expr Expr) (Expr, error) {
 				}
 			}
 		}
-		//
-		// ntt := t.nextNonSpace()
-		// if ntt.tokenType == tokenOperator {
-		// 	nxop, ok := binaryOperators[ntt.value]
-		// 	if !ok {
-		// 		return nil, newUnexpectedTokenError(ntt)
-		// 	}
-		// 	if nxop.precedence < op.precedence || (nxop.precedence == op.precedence && op.leftAssoc()) {
-		// 		t.backup()
-		// 		return t.parseOuterExpr(NewBinaryExpr(expr, op.Operator(), right, expr.Start()))
-		// 	}
-		// 	t.backup()
-		// 	right, err = t.parseOuterExpr(right)
-		// 	if err != nil {
-		// 		return nil, err
-		// 	}
-		// } else {
-		// 	t.backup()
-		// }
 		return NewBinaryExpr(expr, op.Operator(), right, expr.Start()), nil
 
 	default:


### PR DESCRIPTION
This fixes #12, fixes #26 so that property accesses and function calls can be used in more places:
* inside array access `prices[item.ID]` 
* on the right side of binary expressions `obj.prop == obj2.prop`