### PR TITLE
Fix parsing of filters on left side of binary expr

### DIFF
--- a/parse/parse.go
+++ b/parse/parse.go
@@ -144,7 +144,7 @@ func (t *Tree) nextNonSpace() token {
 	var next token
 	for {
 		next = t.next()
-		if next.tokenType != tokenWhitespace || next.tokenType == tokenEOF {
+		if next.tokenType != tokenWhitespace {
 			return next
 		}
 	}

--- a/parse/parse_expr.go
+++ b/parse/parse_expr.go
@@ -72,6 +72,20 @@ func (t *Tree) parseOuterExpr(expr Expr) (Expr, error) {
 				return nil, err
 			}
 			switch n := nx.(type) {
+			case *BinaryExpr:
+				switch b := n.Left.(type) {
+				case *NameExpr:
+					v := NewFilterExpr(b.Name, []Expr{expr}, nt.Pos)
+					n.Left = v
+					return n, nil
+				case *FuncExpr:
+					b.Args = append([]Expr{expr}, b.Args...)
+					v := NewFilterExpr(b.Name, b.Args, nt.Pos)
+					n.Left = v
+					return n, nil
+				default:
+					return nil, newUnexpectedTokenError(nt)
+				}
 			case *NameExpr:
 				return NewFilterExpr(n.Name, []Expr{expr}, nt.Pos), nil
 

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -334,6 +334,16 @@ var parseTests = []parseTest{
 		mkModule(NewPrintNode(NewGetAttrExpr(NewNameExpr("prices", noPos), NewGetAttrExpr(NewNameExpr("item", noPos), NewStringExpr("ID", noPos), nil, noPos), nil, noPos), noPos)),
 	),
 	newParseTest(
+		"filter application inside a binary expression",
+		`{% if name|default(1) >= 0 %}{% endif %}`,
+		mkModule(NewIfNode(NewBinaryExpr(NewFilterExpr("default", []Expr{NewNameExpr("name", noPos), NewNumberExpr("1", noPos)}, noPos), OpBinaryGreaterEqual, NewNumberExpr("0", noPos), noPos), NewBodyNode(noPos), NewBodyNode(noPos), noPos)),
+	),
+	newParseTest(
+		"simple filter application inside a binary expression",
+		`{% if name|keys > 0 %}{% endif %}`,
+		mkModule(NewIfNode(NewBinaryExpr(NewFilterExpr("keys", []Expr{NewNameExpr("name", noPos)}, noPos), OpBinaryGreaterThan, NewNumberExpr("0", noPos), noPos), NewBodyNode(noPos), NewBodyNode(noPos), noPos)),
+	),
+	newParseTest(
 		"property access inside array access",
 		`{{ get_index(item.ID, prices)*item.Quantity }}`,
 		mkModule(


### PR DESCRIPTION
This fixes 
```
{% if keys|length > 0 %}
```
and 
```
{% if something|default(1) > 0 %}
``` 