### PR TITLE
Fix evaluation of 'or' operator in exec.go

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -611,7 +611,7 @@ func (s *state) evalExpr(exp parse.Expr) (v Value, e error) {
 		case parse.OpBinaryAnd:
 			return CoerceBool(left) && CoerceBool(right), nil
 		case parse.OpBinaryOr:
-			return CoerceBool(left) && CoerceBool(right), nil
+			return CoerceBool(left) || CoerceBool(right), nil
 		}
 	case *parse.FuncExpr:
 		return s.evalFunction(exp)

--- a/exec_test.go
+++ b/exec_test.go
@@ -131,6 +131,12 @@ var tests = []execTest{
 		emptyCtx,
 		expect("1"),
 	},
+	{
+		"Comparison with or",
+		`{% if item1 == "banana" or item2 == "apple" %}At least one item is correct{% else %}neither item is correct{% endif %}`,
+		map[string]Value{"item1": "orange", "item2": "apple"},
+		expect("At least one item is correct"),
+	},
 }
 
 type expectedChecker func(actual string) (string, bool)


### PR DESCRIPTION
This fixes #30 -- turns out it was doing `&&` instead of `||` 😅 