### PR TITLE
Don't die when looking up non-existent map elements

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -23,9 +23,9 @@ type state struct {
 	name string    // The name of the template.
 	meta *metadata // Additional template metadata.
 
-	current *parse.BlockNode // Current block, may be nil.
-	blocks []map[string]*parse.BlockNode // Block scopes.
-	macros map[string]*parse.MacroNode   // Imported macros.
+	current *parse.BlockNode              // Current block, may be nil.
+	blocks  []map[string]*parse.BlockNode // Block scopes.
+	macros  map[string]*parse.MacroNode   // Imported macros.
 
 	env   *Env        // The configured Stick environment.
 	scope *scopeStack // Handles execution scope.
@@ -643,7 +643,7 @@ func (s *state) evalExpr(exp parse.Expr) (v Value, e error) {
 		}
 		v, err = GetAttr(c, k, args...)
 		if err != nil {
-			return nil, err
+			e = err
 		}
 	case *parse.TestExpr:
 		if tfn, ok := s.env.Tests[exp.Name]; ok {

--- a/exec_test.go
+++ b/exec_test.go
@@ -58,7 +58,9 @@ var tests = []execTest{
 	},
 	{"In and not in", `{{ 5 in set and 4 not in set }}`, map[string]Value{"set": []int{5, 10}}, expect(`1`)},
 	{"Function call", `{{ multiply(num, 5) }}`, map[string]Value{"num": 10}, expect(`50`)},
+	{"Filter call", `Welcome, {{ name }}`, emptyCtx, expect(`Welcome, `)},
 	{"Filter call", `Welcome, {{ name|default('User') }}`, map[string]Value{"name": nil}, expect(`Welcome, User`)},
+	{"Filter call", `Welcome, {{ surname|default('User') }}`, map[string]Value{"name": nil}, expect(`Welcome, User`)},
 	{
 		"Basic use statement",
 		`{% extends '{% block message %}{% endblock %}' %}{% use '{% block message %}Hello{% endblock %}' %}`,
@@ -136,6 +138,18 @@ var tests = []execTest{
 		`{% if item1 == "banana" or item2 == "apple" %}At least one item is correct{% else %}neither item is correct{% endif %}`,
 		map[string]Value{"item1": "orange", "item2": "apple"},
 		expect("At least one item is correct"),
+	},
+	{
+		"Non-existent map element without default",
+		`{{ data.A }} {{ data.NotThere }} {{ data.B }}`,
+		map[string]Value{"data": map[string]string{"A": "Foo", "B": "Bar"}},
+		expect("Foo  Bar"),
+	},
+	{
+		"Non-existent map element with default",
+		`{{ data.A }} {{ data.NotThere|default("default value") }} {{ data.B }}`,
+		map[string]Value{"data": map[string]string{"A": "Foo", "B": "Bar"}},
+		expect("Foo default value Bar"),
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/tyler-sommer/stick
 
+go 1.12
+
 require github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24


### PR DESCRIPTION
Hi,

I noticed that the `default` filter didn't work when used with map values, as the parser just stopped parsing if a key didn't exist in the map.

This patch will instead return nil and continue parsing, making the `default` filter work correctly.

Sorry for the other unrelated "fixes". Goland insists on "autofixing" the code with the gofmt conventions before doing a commit. Let me know if they are a problem and I'll see if I can find a way to remove them.
