### PR TITLE
fix pop panic when length is 0

### DIFF
--- a/twig/escape.go
+++ b/twig/escape.go
@@ -70,7 +70,9 @@ func (v *autoEscapeVisitor) push(name string) {
 
 // pop removes the top-most name on the stack.
 func (v *autoEscapeVisitor) pop() {
-	v.stack = v.stack[0 : len(v.stack)-1]
+	if len(v.stack) > 0 {
+		v.stack = v.stack[0 : len(v.stack)-1]
+	}
 }
 
 func (v *autoEscapeVisitor) current() string {


### PR DESCRIPTION
Hi,

on rare occasions (not sure why - I cannot really create a working failed state, as this happens at random) the twig autoEscapeVisitor is empty and throws a panic when pop() is called. Looks like this:

```
http: panic serving 172.17.0.1:42832: runtime error: slice bounds out of range [:-1]
goroutine 10919 [running]:
net/http.(*conn).serve.func1(0xc000443360)
	/usr/local/go/src/net/http/server.go:1804 +0x153
panic(0xa1d120, 0xc00038e978)
	/usr/local/go/src/runtime/panic.go:971 +0x499
github.com/tyler-sommer/stick/twig.(*autoEscapeVisitor).pop(...)
	/go/pkg/mod/github.com/tyler-sommer/stick@v1.0.3/twig/escape.go:73
github.com/tyler-sommer/stick/twig.(*autoEscapeVisitor).Leave(0xc0000a2750, 0xaf2290, 0xc0001cb960)
	/go/pkg/mod/github.com/tyler-sommer/stick@v1.0.3/twig/escape.go:105 +0x7
...
```

This PR should take care of that. 