### PR TITLE
Added support for verbatim tag

### DIFF
--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -357,6 +357,11 @@ var parseTests = []parseTest{
 						NewNameExpr("item", noPos),
 						NewStringExpr("Quantity", noPos), nil, noPos), noPos), noPos)),
 	),
+	newParseTest(
+		"verbatim tag",
+		"{% verbatim %}{{as is}}{% endverbatim %}",
+		mkModule(NewTextNode("{{as is}}", noPos)),
+	),
 }
 
 func nodeEqual(a, b Node) bool {


### PR DESCRIPTION
Enable support to copy content that appears within verbatim tag

```
{% verbatim %}
Content to be copied without {{parsing}}
{% endverbatim %}
```