### PR TITLE
Fix to allow "now" on the date filter

### DIFF
--- a/twig/filter/filter.go
+++ b/twig/filter/filter.go
@@ -133,8 +133,15 @@ func filterDate(ctx stick.Context, val stick.Value, args ...stick.Value) stick.V
 	var requestedLayout string
 	dt, ok := val.(time.Time)
 	if !ok {
-		// TODO: trigger runtime error
-		return nil
+		// if the value is a string of "now" then we can use the current time
+		// @doc https://twig.symfony.com/doc/3.x/filters/date.html
+		valString := stick.CoerceString(val)
+		if strings.ToLower(valString) == "now" {
+			dt = time.Now()
+		} else {
+			// TODO: trigger runtime error
+			return nil
+		}
 	}
 
 	if l := len(args); l >= 1 {

--- a/twig/filter/filter_test.go
+++ b/twig/filter/filter_test.go
@@ -69,6 +69,7 @@ func TestFilters(t *testing.T) {
 		{"date u", func() stick.Value { return filterDate(nil, testDate2, "s.u") }, "44.123456"},
 		{"date S", func() stick.Value { return filterDate(nil, testDate, "S") }, "st"},
 		{"date S 2", func() stick.Value { return filterDate(nil, testDate2, "S") }, "rd"},
+		{"date now", func() stick.Value { return filterDate(nil, "now", "Y-m-d") }, time.Now().Format("2006-01-02")},
 		{"join", func() stick.Value { return filterJoin(nil, []string{"a", "b", "c"}, "-") }, "a-b-c"},
 		{"round common down", func() stick.Value { return filterRound(nil, 3.4) }, 3.0},
 		{"round common up", func() stick.Value { return filterRound(nil, 3.6) }, 4.0},


### PR DESCRIPTION
This pull request adds the functionality to pass "now" to a date filter. 