### PR TITLE
Added "raw" tag support similar to "verbatim"

### DIFF
--- a/parse/parse_tag.go
+++ b/parse/parse_tag.go
@@ -43,8 +43,8 @@ func (t *Tree) parseTag() (Node, error) {
 		return parseImport(t, name.Pos)
 	case "from":
 		return parseFrom(t, name.Pos)
-	case "verbatim":
-		return parseVerbatim(t, name.Pos)
+	case "verbatim", "raw":
+		return parseVerbatim(t, name.Pos, name.Value)
 	default:
 		return nil, newUnexpectedTokenError(name)
 	}
@@ -683,9 +683,8 @@ func parseFrom(t *Tree, start Pos) (Node, error) {
 // parseVerbatim pulls body content within verbatim tag.
 //
 //	{% verbatim %} body {% endverbatim %}
-func parseVerbatim(t *Tree, start Pos) (Node, error) {
-	tagName := "verbatim"
-
+//      {% raw %} body {% endraw %}
+func parseVerbatim(t *Tree, start Pos, tagName string) (Node, error) {
 	body := bytes.Buffer{}
 
 	if _, err := t.expect(tokenTagClose); err != nil {

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -367,6 +367,11 @@ var parseTests = []parseTest{
 		"{% verbatim %}{{as is}}{% endverbatim %}",
 		mkModule(NewTextNode("{{as is}}", noPos)),
 	),
+	newParseTest(
+		"raw tag",
+		"{% raw %}{{as is}}{% endraw %}",
+		mkModule(NewTextNode("{{as is}}", noPos)),
+	),
 }
 
 func nodeEqual(a, b Node) bool {


### PR DESCRIPTION
```
{% raw %} body {% endraw %}
```