### PR TITLE
Handle ternary precedence in 'is' and 'is not' tests

### DIFF
--- a/parse/parse_expr.go
+++ b/parse/parse_expr.go
@@ -146,6 +146,25 @@ func (t *Tree) parseOuterExpr(expr Expr) (Expr, error) {
 			if err != nil {
 				return nil, err
 			}
+			// Handle ternary specially
+			if v := t.peekNonSpace(); v.tokenType == tokenPunctuation && v.value == "?" {
+				t.nextNonSpace()
+				tx, err := t.parseExpr()
+				if err != nil {
+					return nil, err
+				}
+				_, err = t.expectValue(tokenPunctuation, ":")
+				if err != nil {
+					return nil, err
+				}
+				fx, err := t.parseExpr()
+				if err != nil {
+					return nil, err
+				}
+				// The BinaryExpr goes inside the TernaryExpr
+				expr = NewBinaryExpr(expr, op.Operator(), right, expr.Start())
+				return NewTernaryIfExpr(expr, tx, fx, expr.Start()), nil
+			}
 		} else {
 			right, err = t.parseExpr()
 			if err != nil {

--- a/parse/parse_expr.go
+++ b/parse/parse_expr.go
@@ -148,22 +148,7 @@ func (t *Tree) parseOuterExpr(expr Expr) (Expr, error) {
 			}
 			// Handle ternary specially
 			if v := t.peekNonSpace(); v.tokenType == tokenPunctuation && v.value == "?" {
-				t.nextNonSpace()
-				tx, err := t.parseExpr()
-				if err != nil {
-					return nil, err
-				}
-				_, err = t.expectValue(tokenPunctuation, ":")
-				if err != nil {
-					return nil, err
-				}
-				fx, err := t.parseExpr()
-				if err != nil {
-					return nil, err
-				}
-				// The BinaryExpr goes inside the TernaryExpr
-				expr = NewBinaryExpr(expr, op.Operator(), right, expr.Start())
-				return NewTernaryIfExpr(expr, tx, fx, expr.Start()), nil
+				return t.parseOuterExpr(NewBinaryExpr(expr, op.Operator(), right, expr.Start()))
 			}
 		} else {
 			right, err = t.parseExpr()

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -367,6 +367,54 @@ var parseTests = []parseTest{
 		"{% verbatim %}{{as is}}{% endverbatim %}",
 		mkModule(NewTextNode("{{as is}}", noPos)),
 	),
+	newParseTest(
+		"is test and ternary",
+		"{{ x is defined ? 1 : 0 }}",
+		mkModule(
+			NewPrintNode(
+				NewTernaryIfExpr(
+					NewBinaryExpr(
+						NewNameExpr("x", noPos),
+						OpBinaryIs,
+						NewTestExpr("defined", nil, noPos), noPos),
+					NewNumberExpr("1", noPos),
+					NewNumberExpr("0", noPos), noPos), noPos))),
+	newParseTest(
+		"is not and ternary",
+		"{{ x is not defined ? 1 : 0 }}",
+		mkModule(
+			NewPrintNode(
+				NewTernaryIfExpr(
+					NewBinaryExpr(
+						NewNameExpr("x", noPos),
+						OpBinaryIsNot,
+						NewTestExpr("defined", nil, noPos), noPos),
+					NewNumberExpr("1", noPos),
+					NewNumberExpr("0", noPos), noPos), noPos))),
+	newParseTest(
+		"is not multi word test function and ternary",
+		"{{ x is not equal to(5) ? 1 : 0 }}",
+		mkModule(
+			NewPrintNode(
+				NewTernaryIfExpr(
+					NewBinaryExpr(
+						NewNameExpr("x", noPos),
+						OpBinaryIsNot,
+						NewTestExpr("equal to", []Expr{NewNumberExpr("5", noPos)}, noPos), noPos),
+					NewNumberExpr("1", noPos),
+					NewNumberExpr("0", noPos), noPos), noPos))),
+	newParseTest(
+		"is test grouped ternary",
+		"{{ (x is defined) ? 1 : 0 }}",
+		mkModule(NewPrintNode(
+			NewTernaryIfExpr(
+				NewGroupExpr(
+					NewBinaryExpr(
+						NewNameExpr("x", noPos),
+						OpBinaryIs,
+						NewTestExpr("defined", nil, noPos), noPos), noPos),
+				NewNumberExpr("1", noPos),
+				NewNumberExpr("0", noPos), noPos), noPos))),
 }
 
 func nodeEqual(a, b Node) bool {


### PR DESCRIPTION
This fixes #54.