### PR TITLE
Fix concurrency bug in excape visitor

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -935,7 +935,12 @@ func (env *Env) load(name string) (*parse.Tree, error) {
 		return nil, err
 	}
 	tree := parse.NewNamedTree(name, tpl.Contents())
-	tree.Visitors = append(tree.Visitors, env.Visitors...)
+	for _, v := range env.Visitors {
+		if cv, ok := v.(parse.CloneableNodeVisitor); ok {
+			v = cv.Clone()
+		}
+		tree.Visitors = append(tree.Visitors, v)
+	}
 	err = tree.Parse()
 	if err != nil {
 		return nil, err

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -13,6 +13,15 @@ type NodeVisitor interface {
 	Leave(Node) // Exit is called before leaving the given Node.
 }
 
+// A CloneableNodeVisitor is a NodeVisitor that carries mutable state and must
+// be cloned before each independent use (e.g. concurrent template parses).
+// Visitors that do not implement this interface are assumed to be stateless
+// and will be shared across parses.
+type CloneableNodeVisitor interface {
+	NodeVisitor
+	Clone() NodeVisitor
+}
+
 // Tree represents the state of a parser.
 type Tree struct {
 	lex *lexer

--- a/twig/escape.go
+++ b/twig/escape.go
@@ -59,8 +59,18 @@ func NewAutoEscapeExtension() *AutoEscapeExtension {
 
 // AutoEscapeVisitor can be used to automatically apply the "escape" filter
 // to any PrintNode.
+//
+// autoEscapeVisitor is stateful (it maintains a stack during tree traversal),
+// so it implements parse.CloneableNodeVisitor to ensure each concurrent parse
+// gets its own instance.
 type autoEscapeVisitor struct {
 	stack []string
+}
+
+// Clone returns a fresh autoEscapeVisitor, ensuring concurrent parses do not
+// share mutable state.
+func (v *autoEscapeVisitor) Clone() parse.NodeVisitor {
+	return &autoEscapeVisitor{}
 }
 
 // push adds the given name on top of the stack.

--- a/twig/escape_test.go
+++ b/twig/escape_test.go
@@ -2,7 +2,9 @@ package twig_test
 
 import (
 	"bytes"
+	"fmt"
 	"os"
+	"sync"
 	"testing"
 
 	"github.com/tyler-sommer/stick"
@@ -73,6 +75,43 @@ func TestAutoEscapeVisitor(t *testing.T) {
 	}
 	if fv := fa.Text; fv != "text" {
 		t.Errorf("expected 'text', got %s", fv)
+	}
+}
+
+func TestAutoEscapeVisitorConcurrent(t *testing.T) {
+	env := twig.New(&stick.MemoryLoader{Templates: map[string]string{
+		"page.html.twig": "<html>{{ body }}</html>",
+	}})
+
+	const goroutines = 10
+	const iterations = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	errs := make(chan error, goroutines*iterations)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				var buf bytes.Buffer
+				err := env.Execute("page.html.twig", &buf, map[string]stick.Value{
+					"body": "<script>alert(1)</script>",
+				})
+				if err != nil {
+					errs <- err
+					return
+				}
+				expected := "<html>&lt;script&gt;alert(1)&lt;/script&gt;</html>"
+				if actual := buf.String(); actual != expected {
+					errs <- fmt.Errorf("expected %q, got %q", expected, actual)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
 	}
 }
 


### PR DESCRIPTION
Bug                                                                                                                                                                                                                                                
   
  autoEscapeVisitor is stateful — it maintains a stack []string that tracks the current escape context as it walks the AST via Enter/Leave. However, AutoEscapeExtension.Init() creates a single shared instance and stores it in env.Visitors. When 
  multiple goroutines call env.Execute() concurrently, env.load() copies that same pointer into each tree, so concurrent parses race on the shared stack slice.

  Fix (3 files)

  1. parse/parse.go — Added a CloneableNodeVisitor interface:
  type CloneableNodeVisitor interface {
      NodeVisitor
      Clone() NodeVisitor
  }
  2. exec.go — env.load() now checks each visitor; if it implements CloneableNodeVisitor, a fresh clone is used instead of the shared instance.
  3. twig/escape.go — autoEscapeVisitor implements Clone(), returning a new zero-value instance so each concurrent parse gets its own stack.

  The approach is backward-compatible: existing stateless visitors that don't implement Clone() continue to work as before.