### PR TITLE
include: support array of candidate names and `ignore missing`

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -290,6 +290,10 @@ func (s *state) walk(node parse.Node) error {
 		if err != nil {
 			return err
 		}
+		if tpl == "" {
+			// No candidate resolved and IgnoreMissing is set — render nothing.
+			return nil
+		}
 		err = execute(tpl, s.out, ctx, s.env)
 		if err != nil {
 			return err
@@ -298,6 +302,11 @@ func (s *state) walk(node parse.Node) error {
 		tpl, ctx, err := s.walkIncludeNode(node.IncludeNode)
 		if err != nil {
 			return err
+		}
+		if tpl == "" {
+			// IgnoreMissing on an embed with no resolvable template —
+			// render nothing and discard the embed body's blocks.
+			return nil
 		}
 		si := newState(tpl, s.out, ctx, s.env)
 		tree, err := s.env.load(tpl)
@@ -401,13 +410,59 @@ func (s *state) walkForNode(node *parse.ForNode) error {
 }
 
 // Method walkInclude determines the necessary parameters for including or embedding a template.
+//
+// The template expression may evaluate to a single name or an array of
+// candidate names. This method picks the first candidate whose template the
+// env's Loader can resolve and returns that name. If none resolve:
+//   - if node.IgnoreMissing is true, returns "" with a nil error so the
+//     caller can skip rendering;
+//   - otherwise, returns the last loader error.
+//
+// Loader-level errors are the only errors swallowed by IgnoreMissing. Errors
+// from parsing or executing a successfully-loaded template still propagate.
 func (s *state) walkIncludeNode(node *parse.IncludeNode) (tpl string, ctx map[string]Value, err error) {
 	ctx = make(map[string]Value)
 	v, err := s.evalExpr(node.Tpl)
 	if err != nil {
 		return "", nil, err
 	}
-	tpl = CoerceString(v)
+
+	// Resolve the candidate list. An array-valued Tpl expression produces
+	// []Value; anything else is treated as a single candidate.
+	var candidates []string
+	switch cands := v.(type) {
+	case []Value:
+		candidates = make([]string, len(cands))
+		for i, c := range cands {
+			candidates[i] = CoerceString(c)
+		}
+	default:
+		candidates = []string{CoerceString(v)}
+	}
+
+	tpl = ""
+	var lastErr error
+	for _, cand := range candidates {
+		if cand == "" {
+			continue
+		}
+		if _, lerr := s.env.Loader.Load(cand); lerr == nil {
+			tpl = cand
+			break
+		} else {
+			lastErr = lerr
+		}
+	}
+	if tpl == "" {
+		if node.IgnoreMissing {
+			return "", ctx, nil
+		}
+		if lastErr != nil {
+			return "", nil, lastErr
+		}
+		return "", nil, fmt.Errorf("include: no template candidates provided")
+	}
+
 	var with Value
 	if n := node.With; n != nil {
 		with, err = s.evalExpr(n)

--- a/exec_test.go
+++ b/exec_test.go
@@ -457,3 +457,93 @@ func (p *fakePerson) Name(prefix string) string {
 	p.name = prefix + p.name
 	return p.name
 }
+
+// TestIncludeArrayAndIgnoreMissing exercises the Twig 3.x array-of-names
+// include and the `ignore missing` modifier. These need a strict loader that
+// actually returns errors for unknown names, so this test builds its own env
+// rather than reusing the one in TestExec (whose testLoader synthesizes
+// templates for unknown names).
+func TestIncludeArrayAndIgnoreMissing(t *testing.T) {
+	// Build an env whose loader knows a small fixed set of templates.
+	// The include-using template is registered under "main" and executed
+	// by name — we can't use the string-loader path because then candidate
+	// names in the include would be resolved as literal template strings.
+	newEnv := func(mainTpl string) *Env {
+		return New(&MemoryLoader{
+			Templates: map[string]string{
+				"main":          mainTpl,
+				"greet.twig":    "Hi {{ who }}",
+				"fallback.twig": "fallback",
+			},
+		})
+	}
+
+	type caseT struct {
+		name   string
+		tpl    string
+		ctx    map[string]Value
+		want   string
+		errSub string // if non-empty, expect an error whose message contains this
+	}
+	cases := []caseT{
+		{
+			name: "array first candidate wins",
+			tpl:  `{% include ['greet.twig', 'fallback.twig'] %}`,
+			ctx:  map[string]Value{"who": "Guy"},
+			want: "Hi Guy",
+		},
+		{
+			name: "array second candidate wins when first missing",
+			tpl:  `{% include ['missing.twig', 'fallback.twig'] %}`,
+			want: "fallback",
+		},
+		{
+			name: "array all missing with ignore missing renders nothing",
+			tpl:  `[{% include ['a.twig', 'b.twig'] ignore missing %}]`,
+			want: "[]",
+		},
+		{
+			name:   "array all missing without ignore errors",
+			tpl:    `{% include ['a.twig', 'b.twig'] %}`,
+			errSub: "does not exist",
+		},
+		{
+			name: "single missing with ignore missing renders nothing",
+			tpl:  `<{% include 'absent.twig' ignore missing %}>`,
+			want: "<>",
+		},
+		{
+			name:   "single missing without ignore errors",
+			tpl:    `{% include 'absent.twig' %}`,
+			errSub: "does not exist",
+		},
+		{
+			name: "ignore missing with with and only",
+			tpl:  `{% include ['missing.twig', 'greet.twig'] ignore missing with {'who': 'Alice'} only %}`,
+			want: "Hi Alice",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			env := newEnv(c.tpl)
+			buf := &bytes.Buffer{}
+			err := env.Execute("main", buf, c.ctx)
+			if c.errSub != "" {
+				if err == nil {
+					t.Fatalf("want error containing %q, got nil (output %q)", c.errSub, buf.String())
+				}
+				if !strings.Contains(err.Error(), c.errSub) {
+					t.Errorf("error %q does not contain %q", err.Error(), c.errSub)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got := buf.String(); got != c.want {
+				t.Errorf("got %q, want %q", got, c.want)
+			}
+		})
+	}
+}

--- a/parse/node.go
+++ b/parse/node.go
@@ -233,19 +233,29 @@ func (t *ForNode) All() []Node {
 type IncludeNode struct {
 	Pos
 	TrimmableNode
-	Tpl  Expr // Expression evaluating to the name of the template to include.
-	With Expr // Explicit list of variables to include in the included template.
-	Only bool // If true, only vars defined in With will be passed.
+	Tpl           Expr // Expression evaluating to the name of the template to include. May evaluate to an array of candidate names (first existing wins).
+	With          Expr // Explicit list of variables to include in the included template.
+	Only          bool // If true, only vars defined in With will be passed.
+	IgnoreMissing bool // If true, render nothing when no candidate template can be loaded instead of erroring.
 }
 
-// NewIncludeNode returns a IncludeNode.
+// NewIncludeNode returns an IncludeNode with IgnoreMissing=false. Preserved
+// for backward compatibility; new callers should prefer
+// NewIncludeNodeWithOptions.
 func NewIncludeNode(tmpl Expr, with Expr, only bool, pos Pos) *IncludeNode {
-	return &IncludeNode{pos, TrimmableNode{}, tmpl, with, only}
+	return NewIncludeNodeWithOptions(tmpl, with, only, false, pos)
+}
+
+// NewIncludeNodeWithOptions is the full constructor, matching the Twig 3.x
+// {% include %} modifier set (template name or array, ignore missing, with
+// <vars>, only).
+func NewIncludeNodeWithOptions(tmpl Expr, with Expr, only, ignoreMissing bool, pos Pos) *IncludeNode {
+	return &IncludeNode{pos, TrimmableNode{}, tmpl, with, only, ignoreMissing}
 }
 
 // String returns a string representation of an IncludeNode.
 func (t *IncludeNode) String() string {
-	return fmt.Sprintf("Include(%s with %s %v)", t.Tpl, t.With, t.Only)
+	return fmt.Sprintf("Include(%s with %s only=%v ignoreMissing=%v)", t.Tpl, t.With, t.Only, t.IgnoreMissing)
 }
 
 // All returns all the child Nodes in a IncludeNode.
@@ -259,9 +269,17 @@ type EmbedNode struct {
 	Blocks map[string]*BlockNode // Blocks inside the embed body.
 }
 
-// NewEmbedNode returns a EmbedNode.
+// NewEmbedNode returns an EmbedNode with IgnoreMissing=false. Preserved for
+// backward compatibility; prefer NewEmbedNodeWithOptions.
 func NewEmbedNode(tmpl Expr, with Expr, only bool, blocks map[string]*BlockNode, pos Pos) *EmbedNode {
-	return &EmbedNode{NewIncludeNode(tmpl, with, only, pos), blocks}
+	return NewEmbedNodeWithOptions(tmpl, with, only, false, blocks, pos)
+}
+
+// NewEmbedNodeWithOptions is the full constructor mirroring
+// NewIncludeNodeWithOptions; ignoreMissing causes the embed to render
+// nothing if no candidate template can be loaded.
+func NewEmbedNodeWithOptions(tmpl Expr, with Expr, only, ignoreMissing bool, blocks map[string]*BlockNode, pos Pos) *EmbedNode {
+	return &EmbedNode{NewIncludeNodeWithOptions(tmpl, with, only, ignoreMissing, pos), blocks}
 }
 
 // String returns a string representation of an EmbedNode.

--- a/parse/parse_tag.go
+++ b/parse/parse_tag.go
@@ -325,16 +325,16 @@ func parseFor(t *Tree, start Pos) (*ForNode, error) {
 
 // parseInclude parses an include statement.
 func parseInclude(t *Tree, start Pos) (Node, error) {
-	expr, with, only, err := parseIncludeOrEmbed(t)
+	expr, with, only, ignoreMissing, err := parseIncludeOrEmbed(t)
 	if err != nil {
 		return nil, err
 	}
-	return NewIncludeNode(expr, with, only, start), nil
+	return NewIncludeNodeWithOptions(expr, with, only, ignoreMissing, start), nil
 }
 
 // parseEmbed parses an embed statement and body.
 func parseEmbed(t *Tree, start Pos) (Node, error) {
-	expr, with, only, err := parseIncludeOrEmbed(t)
+	expr, with, only, ignoreMissing, err := parseIncludeOrEmbed(t)
 	if err != nil {
 		return nil, err
 	}
@@ -369,35 +369,47 @@ func parseEmbed(t *Tree, start Pos) (Node, error) {
 		}
 	}
 	blockRefs := t.popBlockStack()
-	return NewEmbedNode(expr, with, only, blockRefs, start), nil
+	return NewEmbedNodeWithOptions(expr, with, only, ignoreMissing, blockRefs, start), nil
 }
 
 // parseIncludeOrEmbed parses an include or embed tag's parameters.
-// TODO: Implement "ignore missing" support
 //
-//	{% include <expr> %}
-//	{% include <expr> with <expr> %}
-//	{% include <expr> with <expr> only %}
-//	{% include <expr> only %}
-func parseIncludeOrEmbed(t *Tree) (expr Expr, with Expr, only bool, err error) {
+// Accepts the Twig 3.x modifier order for {% include %} / {% embed %}:
+//
+//	{% include <expr> [ignore missing] [with <expr>] [only] %}
+//
+// The template expression may evaluate to a single name or an array of
+// candidate names; array handling is performed at execution time.
+func parseIncludeOrEmbed(t *Tree) (expr Expr, with Expr, only, ignoreMissing bool, err error) {
 	expr, err = t.parseExpr()
 	if err != nil {
 		return
 	}
-	only = false
+
+	// Optional: ignore missing. Must appear before `with` and `only`.
+	if tok := t.peekNonSpace(); tok.tokenType == tokenName && tok.value == "ignore" {
+		t.next()
+		miss := t.nextNonSpace()
+		if miss.tokenType != tokenName || miss.value != "missing" {
+			err = newUnexpectedValueError(miss, "missing")
+			return
+		}
+		ignoreMissing = true
+	}
+
 	switch tok := t.peekNonSpace(); tok.tokenType {
 	case tokenEOF:
 		err = newUnexpectedEOFError(tok)
 		return
 	case tokenName:
-		if tok.value == "only" { // {% include <expr> only %}
+		if tok.value == "only" { // {% include <expr> [ignore missing] only %}
 			t.next()
 			_, err = t.expect(tokenTagClose)
 			if err != nil {
 				return
 			}
 			only = true
-			return expr, with, only, nil
+			return
 		} else if tok.value != "with" {
 			err = newUnexpectedTokenError(tok)
 			return

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -209,6 +209,50 @@ var parseTests = []parseTest{
 		mkModule(NewIncludeNode(NewStringExpr("::_subnav.html.twig", noPos), nil, true, noPos)),
 	),
 	newParseTest(
+		"include ignore missing",
+		"{% include 'optional.twig' ignore missing %}",
+		mkModule(NewIncludeNodeWithOptions(NewStringExpr("optional.twig", noPos), nil, false, true, noPos)),
+	),
+	newParseTest(
+		"include array",
+		"{% include ['a.twig', 'b.twig'] %}",
+		mkModule(NewIncludeNode(
+			NewArrayExpr(noPos, NewStringExpr("a.twig", noPos), NewStringExpr("b.twig", noPos)),
+			nil, false, noPos,
+		)),
+	),
+	newParseTest(
+		"include array ignore missing",
+		"{% include ['a.twig', 'b.twig'] ignore missing %}",
+		mkModule(NewIncludeNodeWithOptions(
+			NewArrayExpr(noPos, NewStringExpr("a.twig", noPos), NewStringExpr("b.twig", noPos)),
+			nil, false, true, noPos,
+		)),
+	),
+	newParseTest(
+		"include all modifiers",
+		"{% include ['a.twig', 'b.twig'] ignore missing with var only %}",
+		mkModule(NewIncludeNodeWithOptions(
+			NewArrayExpr(noPos, NewStringExpr("a.twig", noPos), NewStringExpr("b.twig", noPos)),
+			NewNameExpr("var", noPos), true, true, noPos,
+		)),
+	),
+	newErrorTest(
+		"include ignore without missing",
+		"{% include 'a.twig' ignore %}",
+		`expected "missing"`,
+	),
+	newErrorTest(
+		"include missing without ignore",
+		"{% include 'a.twig' missing %}",
+		`unexpected token "NAME"`,
+	),
+	newErrorTest(
+		"include ignore missing after with (wrong order)",
+		"{% include 'a.twig' with var ignore missing %}",
+		`unexpected token "NAME"`,
+	),
+	newParseTest(
 		"embed",
 		"{% embed '::_modal.html.twig' %}{% block title %}Hello{% endblock %}{% endembed  %}",
 		mkModule(NewEmbedNode(NewStringExpr("::_modal.html.twig", noPos), nil, false, map[string]*BlockNode{"title": NewBlockNode("title", NewBodyNode(noPos, NewTextNode("Hello", noPos)), noPos)}, noPos)),


### PR DESCRIPTION
Addresses the TODO at `parse/parse_tag.go:376` and adds the matching array-of-names form. Semantics match PHP Twig 3.x ([include tag docs](https://twig.symfony.com/doc/3.x/tags/include.html)).

## Syntax now accepted

```twig
{% include <expr> [ignore missing] [with <expr>] [only] %}
```

where `<expr>` may evaluate to a single string or to an array of candidate names. First candidate whose template the loader can resolve wins; if none resolve and `ignore missing` is set, the tag renders nothing instead of erroring.

## What changed

| File | Change |
|---|---|
| `parse/node.go` | `IncludeNode` gains `IgnoreMissing bool`. New full constructors `NewIncludeNodeWithOptions` / `NewEmbedNodeWithOptions`; existing `NewIncludeNode` / `NewEmbedNode` retained as shims with `IgnoreMissing=false` so downstream code compiles unchanged. |
| `parse/parse_tag.go` | `parseIncludeOrEmbed` grows an optional `ignore missing` phase between the template expression and the `with`/`only` modifiers. Emits `expected "missing"` on malformed `ignore`. Doc comment updated. |
| `exec.go` | `walkIncludeNode` resolves the template expression to a candidate slice (`[]Value` → per-element `CoerceString`; otherwise single-element slice). Picks the first candidate for which `env.Loader.Load` succeeds. If none do and `IgnoreMissing`, returns `tpl == "", err == nil`; callers for both `*parse.IncludeNode` and `*parse.EmbedNode` check this and skip rendering. |
| `parse/parse_test.go` | 4 new positive cases (`ignore missing`, array, array + `ignore missing`, all modifiers) + 3 malformed-syntax cases. |
| `exec_test.go` | New `TestIncludeArrayAndIgnoreMissing` with 7 subtests covering first-match-wins, later-match-wins, all-missing ± `ignore missing`, single missing ± `ignore missing`, and full-combo with `with`+`only`. |

## Back-compat

- Existing include/embed test vectors pass unchanged.
- Public constructors `NewIncludeNode` / `NewEmbedNode` are preserved with identical signatures and semantics.
- `IncludeNode.String()` now includes the new flag (debug-format only; no callers in-tree depend on the exact string).

## Semantics notes

- `ignore missing` only swallows errors from `Loader.Load`. Parse or execution errors inside a successfully-loaded template still propagate. This matches PHP Twig 3.x, where `\Twig\Error\LoaderError` is the only exception caught by the `ignoreMissing` branch.
- Empty candidate strings in an array are skipped (fall through to the next candidate) so that `{% include [some_var_that_might_be_empty, 'fallback.twig'] %}` does the intuitive thing.
- Modifier order is fixed at `<expr> [ignore missing] [with] [only]`, matching the Twig 3.x spec. Writing them out of order (e.g. `with foo ignore missing`) errors.

## How to verify

```sh
go test ./...
go vet ./...
```

Both clean against `main` after applying the commits.