### PR TITLE
parse: accept optional NAME in {% endblock NAME %}, validate match

### DIFF
--- a/parse/parse_tag.go
+++ b/parse/parse_tag.go
@@ -131,11 +131,12 @@ func parseExtends(t *Tree, start Pos) (Node, error) {
 	return n, nil
 }
 
-// parseBlock parses a block and any body it may contain.
-// TODO: {% endblock <name> %} support
+// parseBlock parses a block and any body it may contain. The closing
+// {% endblock %} may optionally repeat the block name; when present it
+// must match the opening name, matching the Twig 3.x spec.
 //
 //	{% block <name> %}
-//	{% endblock %}
+//	{% endblock [<name>] %}
 func parseBlock(t *Tree, start Pos) (Node, error) {
 	blockName, err := t.expect(tokenName)
 	if err != nil {
@@ -145,7 +146,24 @@ func parseBlock(t *Tree, start Pos) (Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	body, err := t.parseUntilEndTag("block", start)
+	// parseUntilTag consumes through the "endblock" keyword but leaves the
+	// tag close (and any intervening tokens) for us to handle — which is
+	// how we pick up the optional trailing name. Preserve the
+	// parseUntilEndTag "unclosed tag" error for the immediate-EOF case.
+	if tok := t.peek(); tok.tokenType == tokenEOF {
+		return nil, newUnclosedTagError("block", start)
+	}
+	body, err := t.parseUntilTag(start, "endblock")
+	if err != nil {
+		return nil, err
+	}
+	if tok := t.peekNonSpace(); tok.tokenType == tokenName {
+		closingName := t.nextNonSpace()
+		if closingName.value != blockName.value {
+			return nil, newUnexpectedValueError(closingName, blockName.value)
+		}
+	}
+	_, err = t.expect(tokenTagClose)
 	if err != nil {
 		return nil, err
 	}

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -65,6 +65,21 @@ var parseTests = []parseTest{
 		mkModule(NewBlockNode("something", NewBodyNode(noPos, NewTextNode("Body", noPos)), noPos)),
 	),
 	newParseTest(
+		"block with matching endblock name",
+		"{% block something %}Body{% endblock something %}",
+		mkModule(NewBlockNode("something", NewBodyNode(noPos, NewTextNode("Body", noPos)), noPos)),
+	),
+	newErrorTest(
+		"block endblock name mismatch",
+		"{% block something %}Body{% endblock other %}",
+		`unexpected "other", expected "something"`,
+	),
+	newErrorTest(
+		"block endblock non-name token",
+		"{% block something %}Body{% endblock 42 %}",
+		`expected "TAG_CLOSE", got "NUMBER"`,
+	),
+	newParseTest(
 		"if",
 		"{% if something %}Do Something{% endif %}",
 		mkModule(NewIfNode(NewNameExpr("something", noPos), NewBodyNode(noPos, NewTextNode("Do Something", noPos)), NewBodyNode(noPos), noPos)),


### PR DESCRIPTION
Closes the TODO at `parse/parse_tag.go:135`. Brings `{% block %}` to PHP Twig 3.x parity: the closing tag may optionally repeat the block name; when present it must match the opening name, otherwise parse error.

## Grammar now accepted

```twig
{% block name %} ... {% endblock %}       # unchanged
{% block name %} ... {% endblock name %}  # new, names must match
```

## What changed

- `parse/parse_tag.go` — `parseBlock` now calls `parseUntilTag(start, "endblock")` directly and handles the close inline, peeking for an optional NAME before the tag close. Preserves the existing "unclosed tag" error for immediate-EOF via an upfront `t.peek()` check so the change is behavior-preserving outside the new case. Shared helper `parseUntilEndTag` is untouched.
- `parse/parse_test.go` — 3 new cases mirroring the existing `simple tag` block test: matching-name happy path, name mismatch error, non-NAME token error.

## Tests

| Case | Expectation |
|---|---|
| `{% block x %}body{% endblock %}` (existing) | unchanged |
| `{% block x %}body{% endblock x %}` | parses identically to the existing form |
| `{% block x %}body{% endblock y %}` | error `unexpected "y", expected "x"` |
| `{% block x %}body{% endblock 42 %}` | error `expected "TAG_CLOSE", got "NUMBER"` |

## Back-compat

- `BlockNode` struct / `NewBlockNode` constructor unchanged — the closing name is validated but not stored (it's redundant with the opening name).
- Every existing test vector (including `unclosed block`, `simple tag`, template inheritance) passes unchanged.

## How to verify

```sh
go test ./...
go vet ./...
```

Clean against `main`.