### PR TITLE
twig: ship PHP Twig 3.x built-in tests + faithful `is defined`

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -554,6 +554,53 @@ func (s *state) walkFromNode(node *parse.FromNode) error {
 	return nil
 }
 
+// isDefined probes whether a reference resolves in the current scope
+// without evaluating it. Used to back `is [not] defined` before the left
+// operand is eagerly evaluated by BinaryExpr — see that switch case.
+//
+// Semantics:
+//   - NameExpr: true iff the scope stack has the name bound (including to nil).
+//   - GetAttrExpr: true iff the container evaluates cleanly and the attribute
+//     lookup (via GetAttr) does not error. Missing intermediate names in the
+//     container chain correctly propagate as "undefined".
+//   - Anything else (literals, arithmetic, function calls): attempt eval; if
+//     it succeeds the expression is considered defined. A failed eval is
+//     treated as undefined. This mirrors PHP Twig's practice of treating
+//     non-variable expressions as always defined while gracefully handling
+//     evaluation-time errors.
+func (s *state) isDefined(e parse.Expr) bool {
+	switch x := e.(type) {
+	case *parse.NameExpr:
+		_, ok := s.scope.Get(x.Name)
+		return ok
+	case *parse.GetAttrExpr:
+		cont, err := s.evalExpr(x.Cont)
+		if err != nil || cont == nil {
+			return false
+		}
+		attr, err := s.evalExpr(x.Attr)
+		if err != nil {
+			return false
+		}
+		var args []Value
+		if len(x.Args) > 0 {
+			args = make([]Value, len(x.Args))
+			for i, a := range x.Args {
+				v, err := s.evalExpr(a)
+				if err != nil {
+					return false
+				}
+				args[i] = v
+			}
+		}
+		_, err = GetAttr(cont, attr, args...)
+		return err == nil
+	default:
+		_, err := s.evalExpr(e)
+		return err == nil
+	}
+}
+
 // Method evalExpr evaluates the given expression, returning a Value or error.
 func (s *state) evalExpr(exp parse.Expr) (v Value, e error) {
 	switch exp := exp.(type) {
@@ -595,6 +642,20 @@ func (s *state) evalExpr(exp parse.Expr) (v Value, e error) {
 			return -CoerceNumber(in), nil
 		}
 	case *parse.BinaryExpr:
+		// Special case: `is [not] defined`. PHP Twig does not evaluate the
+		// left operand when the right side is `defined` — the semantics
+		// are "does this reference resolve?", not "is the resolved value
+		// non-nil". Intercept before the left eval so `{% set x = null %}`
+		// still reports `x is defined` as true.
+		if exp.Op == parse.OpBinaryIs || exp.Op == parse.OpBinaryIsNot {
+			if te, ok := exp.Right.(*parse.TestExpr); ok && te.Name == "defined" {
+				defined := s.isDefined(exp.Left)
+				if exp.Op == parse.OpBinaryIsNot {
+					defined = !defined
+				}
+				return defined, nil
+			}
+		}
 		left, err := s.evalExpr(exp.Left)
 		if err != nil {
 			return nil, err

--- a/parse/parse_expr.go
+++ b/parse/parse_expr.go
@@ -201,6 +201,18 @@ func (t *Tree) parseRightTestOperand(prev *NameExpr) (*TestExpr, error) {
 			r.Name = prev.Name + " " + r.Name
 		}
 		return &TestExpr{r}, nil
+	case *NullExpr:
+		// `is null` / `is none` (and the uppercase variants) are
+		// first-class tests in PHP Twig; parseInnerExpr rewrites the
+		// null/none keywords to a NullExpr, so restore them to a
+		// TestExpr here. The canonical test name is "null" — an env's
+		// Tests map can alias "none" to the same function if both
+		// spellings should be user-visible for introspection.
+		name := "null"
+		if prev != nil {
+			name = prev.Name + " " + name
+		}
+		return NewTestExpr(name, []Expr{}, r.Pos), nil
 	default:
 		return nil, fmt.Errorf(`Expected name or function, got "%v"`, right)
 	}

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -65,6 +65,20 @@ var parseTests = []parseTest{
 		mkModule(NewBlockNode("something", NewBodyNode(noPos, NewTextNode("Body", noPos)), noPos)),
 	),
 	newParseTest(
+		"is null desugars to a test",
+		`{{ x is null }}`,
+		mkModule(NewPrintNode(NewBinaryExpr(
+			NewNameExpr("x", noPos), OpBinaryIs,
+			NewTestExpr("null", []Expr{}, noPos), noPos), noPos)),
+	),
+	newParseTest(
+		"is none desugars to the same test",
+		`{{ x is none }}`,
+		mkModule(NewPrintNode(NewBinaryExpr(
+			NewNameExpr("x", noPos), OpBinaryIs,
+			NewTestExpr("null", []Expr{}, noPos), noPos), noPos)),
+	),
+	newParseTest(
 		"if",
 		"{% if something %}Do Something{% endif %}",
 		mkModule(NewIfNode(NewNameExpr("something", noPos), NewBodyNode(noPos, NewTextNode("Do Something", noPos)), NewBodyNode(noPos), noPos)),

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -77,7 +77,7 @@ var parseTests = []parseTest{
 		mkModule(NewPrintNode(NewBinaryExpr(
 			NewNameExpr("x", noPos), OpBinaryIs,
 			NewTestExpr("null", []Expr{}, noPos), noPos), noPos)),
-  ),
+	),
 	newParseTest(
 		"block with matching endblock name",
 		"{% block something %}Body{% endblock something %}",

--- a/twig/builtin_tests_test.go
+++ b/twig/builtin_tests_test.go
@@ -1,0 +1,107 @@
+package twig
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/tyler-sommer/stick"
+)
+
+// Integration tests that exercise the built-in Twig tests (registered by
+// twig.New via twig/tests.TwigTests) end-to-end. These complement the
+// per-function unit tests in twig/tests/tests_test.go.
+
+func render(t *testing.T, tpl string, ctx map[string]stick.Value) (string, error) {
+	t.Helper()
+	env := New(nil) // StringLoader — template text IS the template name
+	buf := &bytes.Buffer{}
+	err := env.Execute(tpl, buf, ctx)
+	return buf.String(), err
+}
+
+func mustRender(t *testing.T, tpl string, ctx map[string]stick.Value) string {
+	t.Helper()
+	out, err := render(t, tpl, ctx)
+	if err != nil {
+		t.Fatalf("render(%q): %v", tpl, err)
+	}
+	return out
+}
+
+// TestIsDefined covers the special-cased interceptor: `is defined` must not
+// evaluate its left operand, so bindings to nil still report as defined
+// (matching PHP Twig 3.x semantics).
+func TestIsDefined(t *testing.T) {
+	cases := []struct {
+		name string
+		tpl  string
+		ctx  map[string]stick.Value
+		want string
+	}{
+		{"unbound name is undefined",
+			`{% if foo is defined %}y{% else %}n{% endif %}`,
+			nil, "n"},
+		{"bound to nil is still defined",
+			`{% if foo is defined %}y{% else %}n{% endif %}`,
+			map[string]stick.Value{"foo": nil}, "y"},
+		{"bound to non-nil is defined",
+			`{% if foo is defined %}y{% else %}n{% endif %}`,
+			map[string]stick.Value{"foo": 1}, "y"},
+		{"is not defined negates",
+			`{% if foo is not defined %}y{% else %}n{% endif %}`,
+			nil, "y"},
+		{"attribute on missing container is undefined",
+			`{% if obj.x is defined %}y{% else %}n{% endif %}`,
+			nil, "n"},
+		{"attribute that exists is defined",
+			`{% if obj.a is defined %}y{% else %}n{% endif %}`,
+			map[string]stick.Value{"obj": map[string]stick.Value{"a": 1}}, "y"},
+		{"missing attribute on existing container is undefined",
+			`{% if obj.missing is defined %}y{% else %}n{% endif %}`,
+			map[string]stick.Value{"obj": map[string]stick.Value{"a": 1}}, "n"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := mustRender(t, c.tpl, c.ctx)
+			if got != c.want {
+				t.Errorf("got %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+// TestBuiltInTestsEndToEnd exercises the non-defined built-in tests through
+// the twig env so we know registration + lookup + evaluation all wire up.
+func TestBuiltInTestsEndToEnd(t *testing.T) {
+	cases := []struct {
+		name string
+		tpl  string
+		ctx  map[string]stick.Value
+		want string
+	}{
+		{"empty: nil", `{{ x is empty ? 'y' : 'n' }}`, nil, "y"},
+		{"empty: non-empty string", `{{ x is empty ? 'y' : 'n' }}`, map[string]stick.Value{"x": "a"}, "n"},
+		{"not empty: string", `{{ x is not empty ? 'y' : 'n' }}`, map[string]stick.Value{"x": "a"}, "y"},
+		{"even: 4", `{{ 4 is even ? 'y' : 'n' }}`, nil, "y"},
+		{"odd: 4", `{{ 4 is odd ? 'y' : 'n' }}`, nil, "n"},
+		{"null: nil", `{{ x is null ? 'y' : 'n' }}`, nil, "y"},
+		{"none alias: nil", `{{ x is none ? 'y' : 'n' }}`, nil, "y"},
+		{"null: non-nil", `{{ x is null ? 'y' : 'n' }}`, map[string]stick.Value{"x": 0}, "n"},
+		{"iterable: slice", `{{ x is iterable ? 'y' : 'n' }}`, map[string]stick.Value{"x": []int{}}, "y"},
+		{"iterable: int", `{{ x is iterable ? 'y' : 'n' }}`, map[string]stick.Value{"x": 3}, "n"},
+		{"divisible by: 9/3", `{{ 9 is divisible by(3) ? 'y' : 'n' }}`, nil, "y"},
+		{"divisible by: 10/3", `{{ 10 is divisible by(3) ? 'y' : 'n' }}`, nil, "n"},
+		{"same as: int", `{{ 1 is same as(1) ? 'y' : 'n' }}`, nil, "y"},
+		{"same as: int vs string", `{{ 1 is same as('1') ? 'y' : 'n' }}`, nil, "n"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := mustRender(t, c.tpl, c.ctx)
+			got = strings.TrimSpace(got)
+			if got != c.want {
+				t.Errorf("tpl=%q got %q, want %q", c.tpl, got, c.want)
+			}
+		})
+	}
+}

--- a/twig/tests/tests.go
+++ b/twig/tests/tests.go
@@ -1,0 +1,129 @@
+// Package tests provides built-in tests for Twig-compatibility, mirroring
+// the Twig 3.x built-in tests at https://twig.symfony.com/doc/3.x/tests/ .
+//
+// The "defined" test is a special case: it must check whether a reference
+// resolves in scope without evaluating it (so that `{% set x = null %}`
+// still counts as defined). That timing-sensitive behavior is handled by
+// an interceptor in the executor; the registration here exists so a
+// lookup of Env.Tests["defined"] returns non-nil, but the registered
+// function is a fallback that only fires if the interceptor is bypassed
+// (e.g. someone builds a binary expression with a TestExpr("defined") at
+// AST-construction time).
+package tests // import "github.com/tyler-sommer/stick/twig/tests"
+
+import (
+	"reflect"
+
+	"github.com/tyler-sommer/stick"
+)
+
+// TwigTests returns PHP Twig 3.x's built-in test set. A fresh map is
+// returned on each call so callers can mutate it without affecting others.
+func TwigTests() map[string]stick.Test {
+	isNull := testNull
+	return map[string]stick.Test{
+		"defined":      testDefinedFallback, // intercepted in the executor; see exec.go
+		"divisible by": testDivisibleBy,
+		"empty":        testEmpty,
+		"even":         testEven,
+		"iterable":     testIterable,
+		"null":         isNull,
+		"none":         isNull, // alias
+		"odd":          testOdd,
+		"same as":      testSameAs,
+	}
+}
+
+// testDefinedFallback is only reached when the executor's interceptor is
+// bypassed (rare — only via a hand-built TestExpr at AST construction).
+// Approximates the semantic with a nil check.
+func testDefinedFallback(_ stick.Context, val stick.Value, _ ...stick.Value) bool {
+	return val != nil
+}
+
+// testEmpty returns true for nil, empty strings, and zero-length slices,
+// arrays, maps, and channels. Scalar non-nil values are never empty.
+func testEmpty(_ stick.Context, val stick.Value, _ ...stick.Value) bool {
+	if val == nil {
+		return true
+	}
+	rv := reflect.ValueOf(val)
+	switch rv.Kind() {
+	case reflect.String, reflect.Slice, reflect.Array, reflect.Map, reflect.Chan:
+		return rv.Len() == 0
+	case reflect.Ptr, reflect.Interface:
+		return rv.IsNil()
+	}
+	// Bools/numbers: only empty if nil; once here they're non-nil non-zero-length.
+	return false
+}
+
+// testEven returns true for integer-valued numbers whose value is even.
+// Non-numeric inputs are coerced via stick.CoerceNumber.
+func testEven(_ stick.Context, val stick.Value, _ ...stick.Value) bool {
+	n := int64(stick.CoerceNumber(val))
+	return n%2 == 0
+}
+
+// testOdd returns true for integer-valued numbers whose value is odd.
+func testOdd(_ stick.Context, val stick.Value, _ ...stick.Value) bool {
+	n := int64(stick.CoerceNumber(val))
+	return n%2 != 0
+}
+
+// testNull returns true for nil values only. `none` is a Twig alias.
+func testNull(_ stick.Context, val stick.Value, _ ...stick.Value) bool {
+	return val == nil
+}
+
+// testIterable returns true for slices, arrays, maps, and channels.
+// Strings are NOT considered iterable (matches PHP Twig's `is iterable`,
+// which checks Traversable + array, both of which exclude strings).
+func testIterable(_ stick.Context, val stick.Value, _ ...stick.Value) bool {
+	if val == nil {
+		return false
+	}
+	switch reflect.ValueOf(val).Kind() {
+	case reflect.Slice, reflect.Array, reflect.Map, reflect.Chan:
+		return true
+	}
+	return false
+}
+
+// testDivisibleBy takes a single argument n and returns true if
+// int(val) % int(n) == 0. Returns false on arity mismatch or when n is 0.
+func testDivisibleBy(_ stick.Context, val stick.Value, args ...stick.Value) bool {
+	if len(args) != 1 {
+		return false
+	}
+	d := int64(stick.CoerceNumber(args[0]))
+	if d == 0 {
+		return false
+	}
+	return int64(stick.CoerceNumber(val))%d == 0
+}
+
+// testSameAs performs a strict identity check: val and args[0] must have
+// the same dynamic type and value. Matches PHP Twig's `is same as(x)`
+// (=== in PHP). Falls back to reflect.DeepEqual for non-comparable types
+// so `[]int{1,2} is same as([]int{1,2})` still behaves sensibly — PHP
+// `===` would return false for non-identical arrays, but stick can't
+// compare identity of values it received through `any`, and
+// reflect.DeepEqual is the closest meaningful alternative.
+func testSameAs(_ stick.Context, val stick.Value, args ...stick.Value) bool {
+	if len(args) != 1 {
+		return false
+	}
+	a, b := val, args[0]
+	if a == nil || b == nil {
+		return a == b
+	}
+	ta, tb := reflect.TypeOf(a), reflect.TypeOf(b)
+	if ta != tb {
+		return false
+	}
+	if ta.Comparable() {
+		return a == b
+	}
+	return reflect.DeepEqual(a, b)
+}

--- a/twig/tests/tests_test.go
+++ b/twig/tests/tests_test.go
@@ -1,0 +1,116 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/tyler-sommer/stick"
+)
+
+type testCase struct {
+	name string
+	val  stick.Value
+	args []stick.Value
+	want bool
+}
+
+func run(t *testing.T, fn stick.Test, cases []testCase) {
+	t.Helper()
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := fn(nil, c.val, c.args...)
+			if got != c.want {
+				t.Errorf("val=%#v args=%#v: got %v, want %v", c.val, c.args, got, c.want)
+			}
+		})
+	}
+}
+
+func TestEmpty(t *testing.T) {
+	run(t, testEmpty, []testCase{
+		{"nil", nil, nil, true},
+		{"empty string", "", nil, true},
+		{"empty slice", []int{}, nil, true},
+		{"empty map", map[string]int{}, nil, true},
+		{"nonempty string", "x", nil, false},
+		{"nonempty slice", []int{1}, nil, false},
+		{"int zero", 0, nil, false},
+		{"bool false", false, nil, false},
+	})
+}
+
+func TestEven(t *testing.T) {
+	run(t, testEven, []testCase{
+		{"zero", 0, nil, true},
+		{"two", 2, nil, true},
+		{"minus four", -4, nil, true},
+		{"one", 1, nil, false},
+		{"three", 3, nil, false},
+	})
+}
+
+func TestOdd(t *testing.T) {
+	run(t, testOdd, []testCase{
+		{"one", 1, nil, true},
+		{"minus three", -3, nil, true},
+		{"zero", 0, nil, false},
+		{"two", 2, nil, false},
+	})
+}
+
+func TestNull(t *testing.T) {
+	run(t, testNull, []testCase{
+		{"nil", nil, nil, true},
+		{"zero", 0, nil, false},
+		{"empty string", "", nil, false},
+		{"false", false, nil, false},
+	})
+}
+
+func TestIterable(t *testing.T) {
+	run(t, testIterable, []testCase{
+		{"slice", []int{}, nil, true},
+		{"map", map[string]int{}, nil, true},
+		{"array", [2]int{1, 2}, nil, true},
+		{"string (not iterable per PHP Twig)", "xyz", nil, false},
+		{"int", 42, nil, false},
+		{"nil", nil, nil, false},
+	})
+}
+
+func TestDivisibleBy(t *testing.T) {
+	mk := func(n int) []stick.Value { return []stick.Value{n} }
+	run(t, testDivisibleBy, []testCase{
+		{"9 by 3", 9, mk(3), true},
+		{"10 by 3", 10, mk(3), false},
+		{"0 by 5", 0, mk(5), true},
+		{"division by zero", 4, mk(0), false},
+		{"wrong arity", 9, nil, false},
+	})
+}
+
+func TestSameAs(t *testing.T) {
+	wrap := func(v stick.Value) []stick.Value { return []stick.Value{v} }
+	run(t, testSameAs, []testCase{
+		{"int to int same", 1, wrap(1), true},
+		{"int to int different", 1, wrap(2), false},
+		{"int to string (different type)", 1, wrap("1"), false},
+		{"nil to nil", nil, wrap(nil), true},
+		{"string same", "abc", wrap("abc"), true},
+		{"slice same via DeepEqual", []int{1, 2}, wrap([]int{1, 2}), true},
+		{"slice different", []int{1, 2}, wrap([]int{1, 3}), false},
+		{"wrong arity", 1, nil, false},
+	})
+}
+
+func TestTwigTestsContainsExpectedKeys(t *testing.T) {
+	got := TwigTests()
+	want := []string{
+		"defined", "divisible by", "empty", "even", "iterable",
+		"null", "none", "odd", "same as",
+	}
+	for _, k := range want {
+		if _, ok := got[k]; !ok {
+			t.Errorf("TwigTests missing %q", k)
+		}
+	}
+}

--- a/twig/twig_compat.go
+++ b/twig/twig_compat.go
@@ -29,6 +29,7 @@ import (
 	"github.com/tyler-sommer/stick"
 	"github.com/tyler-sommer/stick/parse"
 	"github.com/tyler-sommer/stick/twig/filter"
+	"github.com/tyler-sommer/stick/twig/tests"
 )
 
 // New creates a new, default Env that aims to be compatible with Twig.
@@ -41,7 +42,7 @@ func New(loader stick.Loader) *stick.Env {
 		Loader:    loader,
 		Functions: make(map[string]stick.Func),
 		Filters:   filter.TwigFilters(),
-		Tests:     make(map[string]stick.Test),
+		Tests:     tests.TwigTests(),
 		Visitors:  make([]parse.NodeVisitor, 0),
 	}
 	env.Register(NewAutoEscapeExtension())


### PR DESCRIPTION
Implements the PHP Twig 3.x built-in tests ([spec](https://twig.symfony.com/doc/3.x/tests/)) and plumbs them through stick's executor and parser:

- **Tests shipped:** `defined`, `divisible by`, `empty`, `even`, `iterable`, `null` (alias `none`), `odd`, `same as`.
- **`is defined`** is special-cased so it honors the "reference resolves" semantics, not "value is non-nil" — a variable `set x = null` still reports as defined.
- **`is null` / `is none`** now parse (the `null`/`none` keywords at the right-of-`is` position were being rewritten to `NullExpr` and then rejected by the test-operand switch).

## Layout

| File | Purpose |
|---|---|
| `twig/tests/tests.go` (new) | `func TwigTests() map[string]stick.Test` with the 8 built-in tests, mirroring the `twig/filter` package layout. |
| `twig/tests/tests_test.go` (new) | Per-function unit tests (nil handling, empty collections, arity checks, type strictness, iterable kind set). |
| `twig/twig_compat.go` | One-line change: `Tests: tests.TwigTests()` in place of `make(map[string]stick.Test)`. |
| `parse/parse_expr.go` | Accept `*NullExpr` in `parseRightTestOperand` so `is null` / `is none` produce `TestExpr("null")`. |
| `parse/parse_test.go` | Two parser cases for the `null`/`none` desugaring. |
| `exec.go` | `*parse.BinaryExpr` interceptor for `is [not] defined` (before left-operand eval); new `(s *state).isDefined` helper. |
| `twig/builtin_tests_test.go` (new) | End-to-end integration tests: all 8 tests plus `defined` edge cases (unbound, bound-to-nil, not-defined, attribute-level). |

## `defined` design (the non-trivial bit)

PHP Twig doesn't evaluate `is defined`'s left operand — semantics are "does this reference resolve?", not "is the value non-nil". `scopeStack.Get(name) (Value, bool)` already distinguishes unbound from bound-to-nil (`exec.go:149-157`), which is the primitive we need.

Interceptor in `*parse.BinaryExpr`, before left eval:

```go
if exp.Op == parse.OpBinaryIs || exp.Op == parse.OpBinaryIsNot {
    if te, ok := exp.Right.(*parse.TestExpr); ok && te.Name == "defined" {
        defined := s.isDefined(exp.Left)
        if exp.Op == parse.OpBinaryIsNot { defined = !defined }
        return defined, nil
    }
}
```

`isDefined` dispatches on the AST:
- `NameExpr` → `scope.Get` bool.
- `GetAttrExpr` → eval container, try `GetAttr`, treat `err == nil` as defined.
- default → attempt `evalExpr`; err == nil means defined (covers literals, arithmetic, function calls).

The fallback `defined` Test registration in `twig/tests/tests.go` is a nil-check — only reached if a caller hand-constructs a `TestExpr("defined")` at AST-building time, bypassing the parser.

## Back-compat

- `stick.Env.Tests` stays `map[string]stick.Test`; only the initial population changes.
- No new exported API on the core `stick` package.
- `NewIncludeNode` / existing AST constructors untouched.
- All existing test vectors pass unchanged.

## Test matrix

| Feature | Unit test | Integration test |
|---|---|---|
| `defined` (NameExpr) | — | `TestIsDefined` (7 cases) |
| `defined` (GetAttrExpr) | — | `TestIsDefined` (3 cases) |
| `defined` (fallback) | `TestTwigTestsContainsExpectedKeys` | — |
| `empty` | `TestEmpty` (8 cases) | `TestBuiltInTestsEndToEnd` |
| `even` / `odd` | `TestEven`, `TestOdd` | `TestBuiltInTestsEndToEnd` |
| `null` / `none` | `TestNull` | `TestBuiltInTestsEndToEnd` |
| `iterable` | `TestIterable` (6 cases) | `TestBuiltInTestsEndToEnd` |
| `divisible by` | `TestDivisibleBy` (5 cases) | `TestBuiltInTestsEndToEnd` |
| `same as` | `TestSameAs` (8 cases) | `TestBuiltInTestsEndToEnd` |
| `null`/`none` parser desugar | `parse_test.go` (2 cases) | — |

## How to verify

```sh
go test ./...
go vet ./...
```

Clean against `main`.