### PR TITLE
parse, exec: don't panic on `{% for x in xs if cond %}` when no item matches

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -281,10 +281,18 @@ func (s *state) walk(node parse.Node) error {
 			return err
 		}
 		if CoerceBool(v) {
+			if node.Body == nil {
+				return nil
+			}
 			return s.walk(node.Body)
-		} else {
-			return s.walk(node.Else)
 		}
+		// Defensive: any caller that constructs an IfNode without an
+		// Else branch (e.g. older AST builders) gets a no-op rather
+		// than a nil-pointer panic from the default switch arm.
+		if node.Else == nil {
+			return nil
+		}
+		return s.walk(node.Else)
 	case *parse.IncludeNode:
 		tpl, ctx, err := s.walkIncludeNode(node)
 		if err != nil {

--- a/exec_test.go
+++ b/exec_test.go
@@ -83,6 +83,19 @@ var tests = []execTest{
 		expect(`110323f221213332103l`),
 	),
 	newExecTest("For else", `{% for i in emptySet %}{{ i }}{% else %}No results.{% endfor %}`, expect(`No results.`), withContext(map[string]Value{"emptySet": []int{}})),
+	// `{% for x in xs if cond %}` builds an IfNode with no else branch.
+	// When the condition is false for every iteration, the executor used
+	// to walk a nil Else and panic — see commit fixing this.
+	newExecTest(
+		"For with if-filter, no matches, no panic",
+		`<{% for n in [1, 2, 3] if n > 10 %}{{ n }}{% endfor %}>`,
+		expect(`<>`),
+	),
+	newExecTest(
+		"For with if-filter, some matches",
+		`{% for n in [1, 2, 3, 4] if n > 2 %}{{ n }}{% endfor %}`,
+		expect(`34`),
+	),
 	newExecTest(
 		"For map",
 		`{% for k, v in data %}Record {{ loop.index }}: {{ k }}: {{ v }}{% if not loop.last %} - {% endif %}{% endfor %}`,

--- a/parse/parse_tag.go
+++ b/parse/parse_tag.go
@@ -301,7 +301,10 @@ func parseFor(t *Tree, start Pos) (*ForNode, error) {
 		return nil, err
 	}
 	if ifCond != nil {
-		body = NewIfNode(ifCond, body, nil, tok.Pos)
+		// Pass an empty body for the else branch so the executor doesn't
+		// have to walk a nil Node when the condition is false. Mirrors
+		// what parseIfBody already guarantees for standalone {% if %}.
+		body = NewIfNode(ifCond, body, NewBodyNode(tok.Pos), tok.Pos)
 	}
 	t.backup()
 	tok = t.next()

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -186,7 +186,7 @@ var parseTests = []parseTest{
 	newParseTest(
 		"for loop",
 		"{% for k, val in something if val %}body{% else %}No results.{% endfor %}",
-		mkModule(NewForNode("k", "val", NewNameExpr("something", noPos), NewIfNode(NewNameExpr("val", noPos), NewBodyNode(noPos, NewTextNode("body", noPos)), nil, noPos), NewBodyNode(noPos, NewTextNode("No results.", noPos)), noPos)),
+		mkModule(NewForNode("k", "val", NewNameExpr("something", noPos), NewIfNode(NewNameExpr("val", noPos), NewBodyNode(noPos, NewTextNode("body", noPos)), NewBodyNode(noPos), noPos), NewBodyNode(noPos, NewTextNode("No results.", noPos)), noPos)),
 	),
 	newParseTest(
 		"include",


### PR DESCRIPTION
Fixes a nil-pointer panic that fires whenever a `{% for %}` loop with an inline `if` filter has no matching item:

```twig
{% for n in [1, 2, 3] if n > 10 %}{{ n }}{% endfor %}
```

Currently:

```
runtime error: invalid memory address or nil pointer dereference
github.com/tyler-sommer/stick.(*state).walk    exec.go:286   (s.walk(node.Else))
```

## Root cause

`parseFor` builds the per-iteration filter as:

```go
body = NewIfNode(ifCond, body, nil, tok.Pos)   // parse/parse_tag.go:304
```

— `Else` is nil. The executor's IfNode walk case calls `s.walk(node.Else)` when the condition is false; `walk(nil)` reaches the `default` switch arm `errors.New("Unknown node " + node.String())`, which panics on `nil.String()`.

Standalone `{% if %}` doesn't hit this because `parseIfBody` explicitly initializes `els` to an empty BodyNode (line 226).

## Fix

Two cooperating changes:

| File | Change |
|---|---|
| `parse/parse_tag.go:304` | Pass `NewBodyNode(tok.Pos)` instead of `nil` so the constructed IfNode never has a nil Else. Mirrors `parseIfBody`. |
| `exec.go` IfNode case | Defensive `if node.Else == nil { return nil }` guard so any caller building IfNodes outside the parser (older code, third-party tooling) gets a clean no-op instead of a panic. |

Both are 1-line edits; together they close the bug from both directions (parser stops creating the broken AST shape; executor stops blowing up on it if it ever sees one).

## Tests

- `parse/parse_test.go` — the existing "for loop" test at line 189 asserts the AST shape; expectation updated from `If(... Else: <nil>)` to `If(... Else: Body[])` to reflect the parser fix.
- `exec_test.go` — two new cases:
  - `For with if-filter, no matches, no panic` — `{% for n in [1,2,3] if n > 10 %}{{ n }}{% endfor %}` renders empty, no error.
  - `For with if-filter, some matches` — verifies the filter still works for matching iterations.

## How to verify

```sh
go test ./...
go vet ./...
```

Clean against `main`.