### PR TITLE
twig/filter: merge hash + list now produces a sequence (not a no-op)

### DIFF
--- a/twig/filter/filter.go
+++ b/twig/filter/filter.go
@@ -360,33 +360,34 @@ func filterMerge(ctx stick.Context, val stick.Value, args ...stick.Value) stick.
 		return nil
 	}
 
-	outMap, isObject := val.(map[string]stick.Value)
-
-	if isObject {
-		argMap, ok := args[0].(map[string]stick.Value)
-
-		if ok {
+	// Hash + hash → string-keyed merge with the right side winning on
+	// conflicts (matches PHP-Twig and PHP's array_merge for hashes).
+	// For mixed hash + list, fall through to the sequence path so the
+	// list elements are appended (the broken hash-only return used to
+	// silently drop them).
+	if outMap, leftIsMap := val.(map[string]stick.Value); leftIsMap {
+		if argMap, rightIsMap := args[0].(map[string]stick.Value); rightIsMap {
 			for k, v := range argMap {
 				outMap[k] = v
 			}
+			return outMap
 		}
-
-		return outMap
-	} else {
-		var out []stick.Value
-
-		stick.Iterate(val, func(k, v stick.Value, l stick.Loop) (bool, error) {
-			out = append(out, v)
-			return false, nil
-		})
-
-		stick.Iterate(args[0], func(k, v stick.Value, l stick.Loop) (bool, error) {
-			out = append(out, v)
-			return false, nil
-		})
-
-		return out
+		// fall through
 	}
+
+	var out []stick.Value
+
+	stick.Iterate(val, func(k, v stick.Value, l stick.Loop) (bool, error) {
+		out = append(out, v)
+		return false, nil
+	})
+
+	stick.Iterate(args[0], func(k, v stick.Value, l stick.Loop) (bool, error) {
+		out = append(out, v)
+		return false, nil
+	})
+
+	return out
 }
 
 func filterNL2BR(ctx stick.Context, val stick.Value, args ...stick.Value) stick.Value {

--- a/twig/filter/filter_test.go
+++ b/twig/filter/filter_test.go
@@ -131,6 +131,37 @@ func TestFilters(t *testing.T) {
 				return
 			},
 		},
+		// merge: hash + list — used to silently drop the list, returning the
+		// hash unchanged. See PR fixing this.
+		{"merge empty hash with list", func() stick.Value {
+			return stickSliceToString(filterMerge(nil, map[string]stick.Value{}, []string{"a", "b"}))
+		}, "a.b"},
+		{"merge accumulator pattern (hash + list, repeated)", func() stick.Value {
+			out := stick.Value(map[string]stick.Value{})
+			out = filterMerge(nil, out, []string{"x"})
+			out = filterMerge(nil, out, []string{"y"})
+			out = filterMerge(nil, out, []string{"z"})
+			return stickSliceToString(out)
+		}, "x.y.z"},
+		{
+			"merge non-empty hash with list",
+			func() stick.Value {
+				return filterMerge(nil, map[string]stick.Value{"a": "1", "b": "2"}, []string{"3"})
+			},
+			func(actual stick.Value) (ex string, ok bool) {
+				ex = "[1 2 3]"
+				if v, isSlice := actual.([]stick.Value); isSlice && len(v) == 3 {
+					seen := map[string]bool{}
+					for _, e := range v {
+						seen[stick.CoerceString(e)] = true
+					}
+					if seen["1"] && seen["2"] && seen["3"] {
+						return ex, true
+					}
+				}
+				return ex, false
+			},
+		},
 		{"urlencode", func() stick.Value { return filterURLEncode(nil, "http://test.com/dude?sweet=33&1=2") }, "http%3A%2F%2Ftest.com%2Fdude%3Fsweet%3D33%261%3D2"},
 		{"raw", func() stick.Value {
 			safeVal, ok := filterRaw(nil, "<p>test</p>").(stick.SafeValue)


### PR DESCRIPTION
Fixes a silent drop in `filterMerge` when the left operand is a hash and the right is a list. Before:

```twig
{% set acc = {} %}
{% for x in items %}
  {% set acc = acc|merge([x]) %}
{% endfor %}
{{ acc|length }}        {# 0, regardless of items #}
```

The hash-on-the-left branch returned `outMap` unchanged whenever `args[0]` failed the `map[string]stick.Value` type assertion, silently dropping the list. The other three combinations (list+list, list+hash, hash+hash) already worked correctly.

## Fix

Restructure the early-return so the hash-only path returns only when the right side is also a hash; otherwise fall through to the existing sequence-building path that uses `stick.Iterate` on both sides (which handles maps and slices uniformly).

```go
if outMap, leftIsMap := val.(map[string]stick.Value); leftIsMap {
    if argMap, rightIsMap := args[0].(map[string]stick.Value); rightIsMap {
        for k, v := range argMap {
            outMap[k] = v
        }
        return outMap
    }
    // fall through to sequence path
}
// Sequence path (handles list+list, list+hash, hash+list).
```

Behavior matrix:

| Left | Right | Before | After |
|---|---|---|---|
| hash | hash | merge as hash, right wins on conflict | unchanged |
| list | list | concat as list | unchanged |
| list | hash | concat (hash values appended) | unchanged |
| **hash** | **list** | **silent no-op (BUG)** | **concat as list (FIXED)** |

PHP-Twig parity: `merge` follows PHP's `array_merge` — when either operand is sequence-like, the result is a sequence. Hash entries are appended in arbitrary order (Go map iteration is unordered, matching PHP's behavior of "string-keyed entries preserved, numeric keys re-assigned").

## Tests

`twig/filter/filter_test.go` gains 3 cases right after the existing `merge object` test:

- `merge empty hash with list` — `{}|merge(['a','b'])` → `[a, b]`. The minimal repro.
- `merge accumulator pattern (hash + list, repeated)` — start with `{}`, merge `[x]`, merge `[y]`, merge `[z]` → `[x, y, z]`. Mirrors the real-world Twig theme that surfaced this.
- `merge non-empty hash with list` — `{a:1, b:2}|merge([3])` → 3-element sequence containing all three values (asserted by length + `seen[]` since map iteration order is unstable).

Existing `merge`, `merge array`, and `merge object` cases all continue to pass.

## Back-compat

No public API change. Anyone whose code relied on the silent no-op was already getting wrong output; this strictly improves correctness.

## How to verify

```sh
go test ./...
go vet ./...
```

Clean against `main`.