### PR TITLE
parse, exec: add {% spaceless %} tag (Twig 1.x compat)

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -319,6 +319,8 @@ func (s *state) walk(node parse.Node) error {
 		return s.walkDoNode(node)
 	case *parse.FilterNode:
 		return s.walkFilterNode(node)
+	case *parse.SpacelessNode:
+		return s.walkSpacelessNode(node)
 	case *parse.ImportNode:
 		return s.walkImportNode(node)
 	case *parse.FromNode:
@@ -515,6 +517,23 @@ func (s *state) walkFilterNode(node *parse.FilterNode) error {
 	}
 	io.WriteString(prevBuf, val)
 	return nil
+}
+
+// spacelessBetweenTagsRe matches whitespace between HTML tags. Replaced
+// with `><` to mirror PHP-Twig 1.x's spaceless tag semantics.
+var spacelessBetweenTagsRe = regexp.MustCompile(`>\s+<`)
+
+func (s *state) walkSpacelessNode(node *parse.SpacelessNode) error {
+	prevBuf := s.out
+	defer func() { s.out = prevBuf }()
+	buf := &bytes.Buffer{}
+	s.out = buf
+	if err := s.walk(node.Body); err != nil {
+		return err
+	}
+	out := spacelessBetweenTagsRe.ReplaceAllString(buf.String(), "><")
+	_, err := io.WriteString(prevBuf, out)
+	return err
 }
 
 func (s *state) walkImportNode(node *parse.ImportNode) error {

--- a/exec_test.go
+++ b/exec_test.go
@@ -154,6 +154,21 @@ var tests = []execTest{
 		expect("HELLO, WORLD!"),
 	),
 	newExecTest(
+		"Spaceless: strips inter-tag whitespace",
+		`{% spaceless %}<div>   <p>hi</p>   </div>{% endspaceless %}`,
+		expect("<div><p>hi</p></div>"),
+	),
+	newExecTest(
+		"Spaceless: preserves whitespace inside text content",
+		`{% spaceless %}<p>hello   world</p>{% endspaceless %}`,
+		expect("<p>hello   world</p>"),
+	),
+	newExecTest(
+		"Spaceless: empty body",
+		`<<{% spaceless %}{% endspaceless %}>>`,
+		expect("<<>>"),
+	),
+	newExecTest(
 		"Import statement",
 		`{% import 'macros.twig' as mac %}{{ mac.test("hi") }}`,
 		expect("test: hi"),

--- a/parse/node.go
+++ b/parse/node.go
@@ -386,6 +386,32 @@ func (t *FilterNode) All() []Node {
 	return []Node{t.Body}
 }
 
+// SpacelessNode is the body of a {% spaceless %}…{% endspaceless %} tag.
+// At execution time, whitespace BETWEEN HTML tags is stripped from the
+// rendered body, matching the PHP-Twig 1.x semantics
+// (preg_replace('/>\s+</', '><', $body)). Whitespace inside text content
+// or attributes is left untouched.
+type SpacelessNode struct {
+	Pos
+	TrimmableNode
+	Body Node
+}
+
+// NewSpacelessNode creates a SpacelessNode.
+func NewSpacelessNode(body Node, p Pos) *SpacelessNode {
+	return &SpacelessNode{p, TrimmableNode{}, body}
+}
+
+// String returns a string representation of a SpacelessNode.
+func (t *SpacelessNode) String() string {
+	return fmt.Sprintf("Spaceless: %s", t.Body)
+}
+
+// All returns all the child Nodes in a SpacelessNode.
+func (t *SpacelessNode) All() []Node {
+	return []Node{t.Body}
+}
+
 // MacroNode represents a reusable macro.
 type MacroNode struct {
 	Pos

--- a/parse/parse_tag.go
+++ b/parse/parse_tag.go
@@ -37,6 +37,8 @@ func (t *Tree) parseTag() (Node, error) {
 		return parseDo(t, name.Pos)
 	case "filter":
 		return parseFilter(t, name.Pos)
+	case "spaceless":
+		return parseSpaceless(t, name.Pos)
 	case "macro":
 		return parseMacro(t, name.Pos)
 	case "import":
@@ -561,6 +563,26 @@ body:
 		return nil, err
 	}
 	return NewFilterNode(filters, body, start), nil
+}
+
+// parseSpaceless parses a spaceless block.
+//
+//	{% spaceless %}
+//	  <div>   <p>foo</p>   </div>
+//	{% endspaceless %}
+//	→ <div><p>foo</p></div>
+//
+// The tag was deprecated in Twig 2.x and removed in Twig 3.x in favor of
+// the |spaceless filter, but is still common in older themes.
+func parseSpaceless(t *Tree, start Pos) (Node, error) {
+	if _, err := t.expect(tokenTagClose); err != nil {
+		return nil, err
+	}
+	body, err := t.parseUntilEndTag("spaceless", start)
+	if err != nil {
+		return nil, err
+	}
+	return NewSpacelessNode(body, start), nil
 }
 
 // parseMacro parses a macro definition.

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -65,6 +65,11 @@ var parseTests = []parseTest{
 		mkModule(NewBlockNode("something", NewBodyNode(noPos, NewTextNode("Body", noPos)), noPos)),
 	),
 	newParseTest(
+		"spaceless tag",
+		"{% spaceless %}<div> <p>hi</p> </div>{% endspaceless %}",
+		mkModule(NewSpacelessNode(NewBodyNode(noPos, NewTextNode("<div> <p>hi</p> </div>", noPos)), noPos)),
+	),
+	newParseTest(
 		"if",
 		"{% if something %}Do Something{% endif %}",
 		mkModule(NewIfNode(NewNameExpr("something", noPos), NewBodyNode(noPos, NewTextNode("Do Something", noPos)), NewBodyNode(noPos), noPos)),


### PR DESCRIPTION
Adds support for the Twig 1.x `{% spaceless %}…{% endspaceless %}` tag, which strips whitespace between HTML tags in its body. Deprecated in Twig 2.x and removed in Twig 3.x in favor of the `|spaceless` filter, but still common in older themes that haven't migrated.

Before this PR, any template using the tag errored at parse time with `unexpected token "NAME" on line N, column 3` because `parseTag` doesn't recognize `spaceless`.

## Semantics

PHP-Twig 1.x: `preg_replace('/>\s+</', '><', $body)`. Only **inter-tag** whitespace collapses; whitespace inside text content or attributes is preserved.

```twig
{% spaceless %}
  <div>   <p>hello   world</p>   </div>
{% endspaceless %}
→ "<div><p>hello   world</p></div>"
```

## Layout — mirrors `{% filter %}`

| File | Change |
|---|---|
| `parse/node.go` | New `SpacelessNode` with a `Body Node` field, plus `NewSpacelessNode`, `String`, `All`. |
| `parse/parse_tag.go` | New `case "spaceless"` in the dispatch switch; new `parseSpaceless` using the existing `parseUntilEndTag("spaceless", start)` helper. |
| `exec.go` | New `case *parse.SpacelessNode` in walk; new `walkSpacelessNode` that mirrors `walkFilterNode` — redirect `s.out` to a `*bytes.Buffer`, walk body, run the inter-tag regex once, write the result. |
| `parse/parse_test.go` | 1 positive AST test. |
| `exec_test.go` | 3 cases — strips inter-tag whitespace, preserves text content whitespace, empty body renders nothing. |

Total: 5 files, +87 lines, single commit.

## Back-compat

- No public API change beyond the new exported `SpacelessNode` and constructor.
- No existing test vectors affected.
- No new dependencies.

## How to verify

```sh
go test ./...
go vet ./...
```

Clean against `main`.