### PR TITLE
value: make CoerceBool truthy for non-empty collections

### DIFF
--- a/value.go
+++ b/value.go
@@ -123,6 +123,13 @@ func CoerceBool(v Value) bool {
 	case Number:
 		return vc.Number() > 0
 	}
+	// Arrays, slices, and maps are truthy when non-empty, matching PHP-Twig's
+	// "if" semantics for collections (empty array → false; non-empty → true).
+	r := reflect.Indirect(reflect.ValueOf(v))
+	switch r.Kind() {
+	case reflect.Array, reflect.Slice, reflect.Map:
+		return r.Len() > 0
+	}
 	return false
 }
 

--- a/value_test.go
+++ b/value_test.go
@@ -96,6 +96,29 @@ func TestValue(t *testing.T) {
 		}
 	}
 
+	// Collections: non-empty slices/arrays/maps are truthy, empty ones are
+	// not. Uses a slice of pairs because slices and maps aren't hashable
+	// and can't be map keys like the scalar tests above.
+	var boolCollectionTests = []struct {
+		name     string
+		value    Value
+		expected bool
+	}{
+		{"empty slice", []Value{}, false},
+		{"non-empty slice", []Value{1}, true},
+		{"empty array", [0]int{}, false},
+		{"non-empty array", [2]int{1, 2}, true},
+		{"empty map", map[string]Value{}, false},
+		{"non-empty map", map[string]Value{"a": 1}, true},
+		{"nil map", map[string]Value(nil), false},
+		{"nil slice", []Value(nil), false},
+	}
+	for _, tc := range boolCollectionTests {
+		if actual := CoerceBool(tc.value); actual != tc.expected {
+			t.Errorf("CoerceBool(%s): got %v expected %v", tc.name, actual, tc.expected)
+		}
+	}
+
 	var numberTests = map[Value]float64{
 		testType{}: 42,
 		"3":        3.0,


### PR DESCRIPTION
## Summary

Make `stick.CoerceBool` return `true` for non-empty arrays, slices, and maps, matching PHP-Twig's `if`-truthiness for collections.

Before: `{% if some_map %}` on a populated map evaluated to `false` because the type switch in `CoerceBool` handled every scalar case then fell through to `return false`. Reflect-based `Kind()` inspection was never attempted.

After: after the scalar cases, reflect on the value's kind once and return `r.Len() > 0` for `Array`, `Slice`, or `Map`. Nil slices/maps resolve to a zero `reflect.Value` and fall through to `return false`, so nil inputs keep matching "empty" as before.

## Background

The PHP-Twig spec treats non-empty arrays/hashes as truthy under `{% if %}` (see the [`if` docs](https://twig.symfony.com/doc/3.x/tags/if.html): "false, 0, an empty array, etc." are the falsy cases). The common idiom `{% if collection %} … {% endif %}` to gate a block on "has entries" silently does nothing under stick until templates rewrite it as `{% if collection|length > 0 %}`.

## Test plan

- [x] New `value_test.go` cases covering empty + non-empty slice/array/map, plus `nil` slice and `nil` map.
- [x] `go test ./...`, `go vet ./...`, `goimports -d -e .` all clean.

## Out of scope

- `CoerceString`, `CoerceNumber` for collections — unrelated paths, separate behavior questions.
- Struct values (non-interface) — intentionally still `false` unless the struct implements `Boolean`.
