### PR TITLE
twig: add built-in max/min functions

### DIFF
--- a/twig/builtin_functions_test.go
+++ b/twig/builtin_functions_test.go
@@ -1,0 +1,35 @@
+package twig
+
+import (
+	"testing"
+
+	"github.com/tyler-sommer/stick"
+)
+
+// TestBuiltinMaxMin exercises twig.New's Functions wiring end-to-end, so a
+// future change that accidentally drops fn.TwigFunctions fails here.
+func TestBuiltinMaxMin(t *testing.T) {
+	cases := []struct {
+		name string
+		tpl  string
+		ctx  map[string]stick.Value
+		want string
+	}{
+		{"max scalars", `{{ max(1, 2, 3) }}`, nil, "3"},
+		{"min scalars", `{{ min(1, 2, 3) }}`, nil, "1"},
+		{"max from slice", `{{ max([4, 1, 9, 2]) }}`, nil, "9"},
+		{"min from slice", `{{ min([4, 1, 9, 2]) }}`, nil, "1"},
+		{"max from hash values",
+			`{{ max(counts) }}`, map[string]stick.Value{
+				"counts": map[string]stick.Value{"a": 2, "b": 7, "c": 5},
+			}, "7"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mustRender(t, tc.tpl, tc.ctx)
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/twig/fn/fn.go
+++ b/twig/fn/fn.go
@@ -1,0 +1,62 @@
+// Package fn provides built-in functions for Twig-compatibility, mirroring
+// the Twig 3.x built-in functions at https://twig.symfony.com/doc/3.x/functions/ .
+package fn // import "github.com/tyler-sommer/stick/twig/fn"
+
+import "github.com/tyler-sommer/stick"
+
+// TwigFunctions returns PHP Twig 3.x's built-in function set. A fresh map
+// is returned on each call so callers can mutate it without affecting
+// others.
+func TwigFunctions() map[string]stick.Func {
+	return map[string]stick.Func{
+		"max": fnMax,
+		"min": fnMin,
+	}
+}
+
+// fnMax returns the largest of its arguments. Mirrors PHP-Twig's max():
+//
+//	max(1, 2, 3)          → 3
+//	max([1, 3, 2])        → 3
+//	max({'a':1,'b':3})    → 3 (hash values)
+//	max()                 → nil
+//
+// Numeric comparison uses stick.CoerceNumber, matching PHP's loose-typing
+// behavior. String comparison is not implemented here — both sides coerce
+// to 0 and the first argument wins. Hashtagueule doesn't exercise that
+// path; add it if a real theme needs it.
+func fnMax(_ stick.Context, args ...stick.Value) stick.Value {
+	return extremum(args, true)
+}
+
+// fnMin returns the smallest of its arguments. See fnMax for semantics.
+func fnMin(_ stick.Context, args ...stick.Value) stick.Value {
+	return extremum(args, false)
+}
+
+func extremum(args []stick.Value, max bool) stick.Value {
+	var best stick.Value
+	seen := false
+	feed := func(v stick.Value) {
+		if !seen {
+			best, seen = v, true
+			return
+		}
+		cur := stick.CoerceNumber(v)
+		top := stick.CoerceNumber(best)
+		if (max && cur > top) || (!max && cur < top) {
+			best = v
+		}
+	}
+	if len(args) == 1 && stick.IsIterable(args[0]) {
+		_, _ = stick.Iterate(args[0], func(_, v stick.Value, _ stick.Loop) (bool, error) {
+			feed(v)
+			return false, nil
+		})
+	} else {
+		for _, a := range args {
+			feed(a)
+		}
+	}
+	return best
+}

--- a/twig/fn/fn_test.go
+++ b/twig/fn/fn_test.go
@@ -1,0 +1,42 @@
+package fn
+
+import (
+	"testing"
+
+	"github.com/tyler-sommer/stick"
+)
+
+func TestMaxMin(t *testing.T) {
+	ts := []struct {
+		name string
+		fn   stick.Func
+		args []stick.Value
+		want stick.Value
+	}{
+		{"max scalars", fnMax, []stick.Value{1, 2, 3}, 3},
+		{"min scalars", fnMin, []stick.Value{1, 2, 3}, 1},
+		{"max slice", fnMax, []stick.Value{[]stick.Value{1, 3, 2}}, 3},
+		{"min slice", fnMin, []stick.Value{[]stick.Value{3, 1, 2}}, 1},
+		{"max hash values", fnMax, []stick.Value{map[string]stick.Value{"a": 1, "b": 3, "c": 2}}, 3},
+		{"max single arg", fnMax, []stick.Value{42}, 42},
+		{"max no args", fnMax, []stick.Value{}, nil},
+		{"min no args", fnMin, []stick.Value{}, nil},
+		{"max float beats int", fnMax, []stick.Value{2, 2.5}, 2.5},
+		{"min negative", fnMin, []stick.Value{-5, -3, -10}, -10},
+	}
+	for _, tc := range ts {
+		got := tc.fn(nil, tc.args...)
+		if got != tc.want {
+			t.Errorf("%s: got %v (%T), want %v (%T)", tc.name, got, got, tc.want, tc.want)
+		}
+	}
+}
+
+func TestTwigFunctionsRegistration(t *testing.T) {
+	fns := TwigFunctions()
+	for _, name := range []string{"max", "min"} {
+		if _, ok := fns[name]; !ok {
+			t.Errorf("TwigFunctions missing %q", name)
+		}
+	}
+}

--- a/twig/twig_compat.go
+++ b/twig/twig_compat.go
@@ -29,6 +29,7 @@ import (
 	"github.com/tyler-sommer/stick"
 	"github.com/tyler-sommer/stick/parse"
 	"github.com/tyler-sommer/stick/twig/filter"
+	"github.com/tyler-sommer/stick/twig/fn"
 	"github.com/tyler-sommer/stick/twig/tests"
 )
 
@@ -40,7 +41,7 @@ func New(loader stick.Loader) *stick.Env {
 	}
 	env := &stick.Env{
 		Loader:    loader,
-		Functions: make(map[string]stick.Func),
+		Functions: fn.TwigFunctions(),
 		Filters:   filter.TwigFilters(),
 		Tests:     tests.TwigTests(),
 		Visitors:  make([]parse.NodeVisitor, 0),


### PR DESCRIPTION
## Summary

Add PHP-Twig's `max` and `min` as built-in Twig functions, via a new `twig/fn` sub-package that mirrors the existing `twig/filter` / `twig/tests` layout.

Before: `twig.New` built its env with `Functions: make(map[string]stick.Func)` — empty. Any template calling `max(…)` or `min(…)` errored with `Undeclared function "max"`. No way to opt in without hand-registering them on every `*stick.Env`.

After: `twig.New` pulls `Functions: fn.TwigFunctions()`. The new package is the canonical home for PHP-Twig built-in functions; this PR ships two, and the docblock points at the broader set (`range`, `cycle`, `date`, `dump`, `constant`, `attribute`, `random`, …) as follow-ups.

## Semantics

Mirrors the PHP-Twig [`max`](https://twig.symfony.com/doc/3.x/functions/max.html) and [`min`](https://twig.symfony.com/doc/3.x/functions/min.html) functions:

- `max(a, b, c, …)` over multiple scalar args.
- `max(iterable)` over a single slice/array/map; hashes compare values.
- `max()` / `min()` with no args returns `nil`.
- `min` is symmetric to `max`.

Comparison uses `stick.CoerceNumber`, matching PHP's loose-typing behavior for numeric inputs.

## Test plan

- [x] Unit tests in `twig/fn/fn_test.go` covering: scalar args, single-slice arg, single-hash arg, no args, float-beats-int, negative numbers.
- [x] Integration test in `twig/builtin_functions_test.go` exercising `twig.New`'s Functions wiring end-to-end (parallels the existing `builtin_tests_test.go` shape).
- [x] `go test ./...`, `go vet ./...`, `goimports -d -e .` all clean.

## Out of scope

- Other PHP-Twig built-in functions. The new `twig/fn` package is explicitly the home for them, but each should land as its own reviewable PR as needed.
- String comparison in `max("a","b")`. PHP's `max()` handles strings via loose compare; `stick.CoerceNumber` on both sides coerces to 0 and the first argument wins. Documented as a known deviation — easy follow-up if needed.
