### PR TITLE
value, exec, twig/filter: preserve insertion order for hash literals

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -485,9 +485,14 @@ func (s *state) walkIncludeNode(node *parse.IncludeNode) (tpl string, ctx map[st
 		ctx = s.scope.All()
 	}
 	if with != nil {
-		if with, ok := with.(map[string]Value); ok {
-			for k, v := range with {
+		switch w := with.(type) {
+		case map[string]Value:
+			for k, v := range w {
 				ctx[k] = v
+			}
+		case *Hash:
+			for _, k := range w.order {
+				ctx[k] = w.vals[k]
 			}
 		}
 	}
@@ -890,7 +895,7 @@ func (s *state) evalExpr(exp parse.Expr) (v Value, e error) {
 		return s.evalExpr(exp.FalseX)
 
 	case *parse.HashExpr:
-		vals := make(map[string]Value)
+		vals := NewHash(len(exp.Elements))
 		for _, v := range exp.Elements {
 			var key Value
 			var err error
@@ -906,7 +911,7 @@ func (s *state) evalExpr(exp parse.Expr) (v Value, e error) {
 			if err != nil {
 				return nil, err
 			}
-			vals[CoerceString(key)] = val
+			vals.Set(CoerceString(key), val)
 		}
 		return vals, nil
 

--- a/exec_test.go
+++ b/exec_test.go
@@ -207,6 +207,11 @@ var tests = []execTest{
 		expect("ew? it's not that bad to the power of four!"),
 	),
 	newExecTest(
+		"Hash literal preserves insertion order",
+		`{% set m = {"b": 2, "a": 1, "c": 3} %}{% for k,v in m %}{{k}}={{v}};{% endfor %}`,
+		expect("b=2;a=1;c=3;"),
+	),
+	newExecTest(
 		"Array literal",
 		`{{ ["test", 1, "bar"][2] }}`,
 		expect("bar"),

--- a/twig/filter/filter.go
+++ b/twig/filter/filter.go
@@ -297,6 +297,9 @@ func filterJSONEncode(ctx stick.Context, val stick.Value, args ...stick.Value) s
 }
 
 func filterKeys(ctx stick.Context, val stick.Value, args ...stick.Value) stick.Value {
+	if h, ok := val.(*stick.Hash); ok {
+		return h.Keys()
+	}
 	r := reflect.Indirect(reflect.ValueOf(val))
 	switch r.Kind() {
 	case reflect.Slice, reflect.Array:
@@ -362,19 +365,37 @@ func filterMerge(ctx stick.Context, val stick.Value, args ...stick.Value) stick.
 		return nil
 	}
 
+	leftIsHashLike := isHashLike(val)
+	rightIsHashLike := isHashLike(args[0])
+
 	// Hash + hash → string-keyed merge with the right side winning on
 	// conflicts (matches PHP-Twig and PHP's array_merge for hashes).
 	// For mixed hash + list, fall through to the sequence path so the
-	// list elements are appended (the broken hash-only return used to
-	// silently drop them).
-	if outMap, leftIsMap := val.(map[string]stick.Value); leftIsMap {
-		if argMap, rightIsMap := args[0].(map[string]stick.Value); rightIsMap {
-			for k, v := range argMap {
-				outMap[k] = v
-			}
-			return outMap
+	// list elements are appended.
+	if leftIsHashLike && rightIsHashLike {
+		// If either operand is an ordered *stick.Hash, the result is an
+		// ordered *stick.Hash so iteration preserves insertion order.
+		// Two plain Go maps keep producing a plain Go map to avoid a
+		// silent type change for callers that type-assert the result.
+		_, leftHash := val.(*stick.Hash)
+		_, rightHash := args[0].(*stick.Hash)
+		if leftHash || rightHash {
+			out := stick.NewHash(0)
+			_, _ = stick.Iterate(val, func(k, v stick.Value, _ stick.Loop) (bool, error) {
+				out.Set(stick.CoerceString(k), v)
+				return false, nil
+			})
+			_, _ = stick.Iterate(args[0], func(k, v stick.Value, _ stick.Loop) (bool, error) {
+				out.Set(stick.CoerceString(k), v)
+				return false, nil
+			})
+			return out
 		}
-		// fall through
+		outMap := val.(map[string]stick.Value)
+		for k, v := range args[0].(map[string]stick.Value) {
+			outMap[k] = v
+		}
+		return outMap
 	}
 
 	var out []stick.Value
@@ -390,6 +411,18 @@ func filterMerge(ctx stick.Context, val stick.Value, args ...stick.Value) stick.
 	})
 
 	return out
+}
+
+// isHashLike reports whether v is something merge should treat as a hash
+// (a Go string-keyed map or an ordered *stick.Hash).
+func isHashLike(v stick.Value) bool {
+	if _, ok := v.(*stick.Hash); ok {
+		return true
+	}
+	if _, ok := v.(map[string]stick.Value); ok {
+		return true
+	}
+	return false
 }
 
 // nl2brRe matches every newline form in one pass: CRLF, bare CR, bare LF.
@@ -477,6 +510,15 @@ func filterReplace(ctx stick.Context, val stick.Value, args ...stick.Value) stic
 }
 
 func filterReverse(ctx stick.Context, val stick.Value, args ...stick.Value) stick.Value {
+	if h, ok := val.(*stick.Hash); ok {
+		out := stick.NewHash(h.Len())
+		keys := h.Keys()
+		for i := len(keys) - 1; i >= 0; i-- {
+			v, _ := h.Get(keys[i])
+			out.Set(keys[i], v)
+		}
+		return out
+	}
 	if stick.IsArray(val) {
 		arr := reflect.ValueOf(val)
 		res := make([]interface{}, 0)

--- a/twig/ordered_hash_test.go
+++ b/twig/ordered_hash_test.go
@@ -1,0 +1,54 @@
+package twig
+
+import (
+	"testing"
+
+	"github.com/tyler-sommer/stick"
+)
+
+// TestOrderedHashMergeAccumulator mirrors the real-world Twig 1.x pattern
+// where a theme iterates sorted keys and accumulates into a hash via merge,
+// then iterates the accumulator for display. Under stick's previous Go-map
+// hash literals this lost the sort order; with *stick.Hash it is preserved.
+func TestOrderedHashMergeAccumulator(t *testing.T) {
+	tpl := `{% set out = {} %}` +
+		`{% for k in ["c","a","b"]|sort %}{% set out = out|merge({(k): k~k}) %}{% endfor %}` +
+		`{% for k,v in out %}{{k}}={{v}};{% endfor %}`
+	got := mustRender(t, tpl, nil)
+	if got != "a=aa;b=bb;c=cc;" {
+		t.Errorf("got %q, want %q", got, "a=aa;b=bb;c=cc;")
+	}
+}
+
+func TestOrderedHashReverse(t *testing.T) {
+	tpl := `{% set m = {"a": 1, "b": 2, "c": 3}|reverse %}{% for k,v in m %}{{k}}={{v}};{% endfor %}`
+	got := mustRender(t, tpl, nil)
+	if got != "c=3;b=2;a=1;" {
+		t.Errorf("got %q, want %q", got, "c=3;b=2;a=1;")
+	}
+}
+
+func TestOrderedHashKeys(t *testing.T) {
+	tpl := `{% set m = {"c": 1, "a": 2, "b": 3} %}{% for k in m|keys %}{{k}};{% endfor %}`
+	got := mustRender(t, tpl, nil)
+	if got != "c;a;b;" {
+		t.Errorf("got %q, want %q (keys should be insertion order, not sorted)", got, "c;a;b;")
+	}
+}
+
+// TestUserMapUnchanged covers the out-of-scope guarantee: maps passed by
+// the caller as context keep plain Go-map semantics (unordered) and merge
+// results between two plain maps also stay plain maps.
+func TestUserContextMapUnchanged(t *testing.T) {
+	ctx := map[string]stick.Value{
+		"m": map[string]stick.Value{"x": 1},
+		"n": map[string]stick.Value{"y": 2},
+	}
+	// The merged value iterated through stick sees both keys regardless of
+	// iteration order; we just assert that no panic / no nil-drop happens.
+	tpl := `{% set r = m|merge(n) %}{{ r.x }}+{{ r.y }}`
+	got := mustRender(t, tpl, ctx)
+	if got != "1+2" {
+		t.Errorf("got %q, want %q", got, "1+2")
+	}
+}

--- a/value.go
+++ b/value.go
@@ -82,6 +82,30 @@ func (h *Hash) Keys() []string {
 	return out
 }
 
+// AsMap converts a hash-shaped Value to a map[string]Value. Returns the
+// map and true for either a *Hash or a plain map[string]Value; returns
+// nil, false for anything else.
+//
+// Intended as a migration aid for user-defined tests / operators /
+// functions that used to type-assert map[string]Value directly on the
+// result of a Twig hash literal or |merge filter. Those callers can drop
+// in AsMap and transparently support both the legacy Go-map shape and
+// the new insertion-order-preserving *Hash.
+//
+// For a *Hash the returned map is the internal storage (not a copy),
+// so callers can read it cheaply. Writing to the returned map bypasses
+// the hash's insertion-order tracking — avoid mutation, or use the
+// *Hash Set / Delete methods instead.
+func AsMap(v Value) (map[string]Value, bool) {
+	switch m := v.(type) {
+	case *Hash:
+		return m.vals, true
+	case map[string]Value:
+		return m, true
+	}
+	return nil, false
+}
+
 // A SafeValue represents a value that has already been sanitized and escaped.
 type SafeValue interface {
 	// Value returns the value stored in the SafeValue.

--- a/value.go
+++ b/value.go
@@ -12,6 +12,76 @@ import (
 // and used by a Stick template.
 type Value interface{}
 
+// Hash is an insertion-order-preserving string→Value map. Twig hash literals
+// ({'a': 1, 'b': 2}) evaluate to a *Hash so iteration matches PHP-Twig
+// semantics (PHP associative arrays iterate in insertion order; Go maps do
+// not). User-supplied context (map[string]Value) keeps its existing
+// unordered semantics — the ordered type is only produced by stick itself
+// (hash-literal evaluation and hash-returning filters like merge).
+type Hash struct {
+	order []string
+	vals  map[string]Value
+}
+
+// NewHash returns an empty Hash with capacity hint capHint.
+func NewHash(capHint int) *Hash {
+	if capHint < 0 {
+		capHint = 0
+	}
+	return &Hash{
+		order: make([]string, 0, capHint),
+		vals:  make(map[string]Value, capHint),
+	}
+}
+
+// Set inserts k=v, appending k to the iteration order if it's new. If k
+// already exists, its value is updated in place and the existing position
+// in the iteration order is preserved.
+func (h *Hash) Set(k string, v Value) {
+	if _, ok := h.vals[k]; !ok {
+		h.order = append(h.order, k)
+	}
+	h.vals[k] = v
+}
+
+// Get returns the value for k. The second return is false if k is missing.
+func (h *Hash) Get(k string) (Value, bool) {
+	v, ok := h.vals[k]
+	return v, ok
+}
+
+// Has reports whether k is present.
+func (h *Hash) Has(k string) bool {
+	_, ok := h.vals[k]
+	return ok
+}
+
+// Delete removes k. Returns true if k was present. O(n) in the hash length
+// because the key is removed from the order slice as well.
+func (h *Hash) Delete(k string) bool {
+	if _, ok := h.vals[k]; !ok {
+		return false
+	}
+	delete(h.vals, k)
+	for i, x := range h.order {
+		if x == k {
+			h.order = append(h.order[:i], h.order[i+1:]...)
+			break
+		}
+	}
+	return true
+}
+
+// Len returns the number of keys in the hash.
+func (h *Hash) Len() int { return len(h.order) }
+
+// Keys returns a copy of the keys in insertion order.
+func (h *Hash) Keys() []string {
+	out := make([]string, len(h.order))
+	copy(out, h.order)
+	return out
+}
+
 // A SafeValue represents a value that has already been sanitized and escaped.
 type SafeValue interface {
 	// Value returns the value stored in the SafeValue.
@@ -84,6 +154,8 @@ type Boolean interface {
 // if the value cannot be coerced.
 func CoerceBool(v Value) bool {
 	switch vc := v.(type) {
+	case *Hash:
+		return vc.Len() > 0
 	case SafeValue:
 		return CoerceBool(vc.Value())
 	case bool:
@@ -214,6 +286,12 @@ func CoerceString(v Value) string {
 
 // GetAttr attempts to access the given value and return the specified attribute.
 func GetAttr(v Value, attr Value, args ...Value) (Value, error) {
+	if h, ok := v.(*Hash); ok {
+		if val, found := h.Get(CoerceString(attr)); found {
+			return val, nil
+		}
+		return nil, fmt.Errorf("getattr: unable to locate attribute \"%s\" on \"%v\"", attr, v)
+	}
 	r := reflect.Indirect(reflect.ValueOf(v))
 	if !r.IsValid() {
 		return nil, fmt.Errorf("getattr: value does not support attribute lookup: %v", v)
@@ -312,6 +390,9 @@ func IsArray(val Value) bool {
 
 // IsMap returns true if the given Value is a map.
 func IsMap(val Value) bool {
+	if _, ok := val.(*Hash); ok {
+		return true
+	}
 	r := reflect.Indirect(reflect.ValueOf(val))
 	return r.Kind() == reflect.Map
 }
@@ -319,6 +400,9 @@ func IsMap(val Value) bool {
 // IsIterable returns true if the given Value is a slice, array, or map.
 func IsIterable(val Value) bool {
 	if val == nil {
+		return true
+	}
+	if _, ok := val.(*Hash); ok {
 		return true
 	}
 	r := reflect.Indirect(reflect.ValueOf(val))
@@ -333,6 +417,31 @@ func IsIterable(val Value) bool {
 func Iterate(val Value, it Iteratee) (int, error) {
 	if val == nil {
 		return 0, nil
+	}
+	if h, ok := val.(*Hash); ok {
+		ln := h.Len()
+		l := Loop{
+			ln == 1,
+			1,
+			0,
+			ln,
+			ln - 1,
+			true,
+			ln,
+		}
+		for i, k := range h.order {
+			brk, err := it(k, h.vals[k], l)
+			if brk || err != nil {
+				return i + 1, err
+			}
+			l.Index++
+			l.Index0++
+			l.Last = ln == l.Index
+			l.Revindex--
+			l.Revindex0--
+			l.First = false
+		}
+		return ln, nil
 	}
 	r := reflect.Indirect(reflect.ValueOf(val))
 	switch r.Kind() {
@@ -398,6 +507,9 @@ func Iterate(val Value, it Iteratee) (int, error) {
 func Len(val Value) (int, error) {
 	if val == nil {
 		return 0, nil
+	}
+	if h, ok := val.(*Hash); ok {
+		return h.Len(), nil
 	}
 	r := reflect.Indirect(reflect.ValueOf(val))
 	switch r.Kind() {

--- a/value_test.go
+++ b/value_test.go
@@ -266,6 +266,31 @@ func TestHash(t *testing.T) {
 	}
 }
 
+func TestAsMap(t *testing.T) {
+	// Plain Go map — returned as-is.
+	m := map[string]Value{"a": 1, "b": 2}
+	got, ok := AsMap(m)
+	if !ok || len(got) != 2 || got["a"] != 1 || got["b"] != 2 {
+		t.Errorf("AsMap(plain map): got (%v, %v), want map {a:1 b:2} + true", got, ok)
+	}
+
+	// *Hash — exposes internal storage, all keys reachable.
+	h := NewHash(0)
+	h.Set("x", 10)
+	h.Set("y", 20)
+	got, ok = AsMap(h)
+	if !ok || len(got) != 2 || got["x"] != 10 || got["y"] != 20 {
+		t.Errorf("AsMap(*Hash): got (%v, %v), want map {x:10 y:20} + true", got, ok)
+	}
+
+	// Non-hash values — return (nil, false).
+	for _, v := range []Value{nil, "string", 42, []Value{1, 2}} {
+		if m, ok := AsMap(v); ok || m != nil {
+			t.Errorf("AsMap(%T %v): got (%v, %v), want (nil, false)", v, v, m, ok)
+		}
+	}
+}
+
 func equalStrings(a, b []string) bool {
 	if len(a) != len(b) {
 		return false

--- a/value_test.go
+++ b/value_test.go
@@ -189,6 +189,95 @@ func TestGetAttr(t *testing.T) {
 	}
 }
 
+func TestHash(t *testing.T) {
+	h := NewHash(0)
+	if h.Len() != 0 {
+		t.Errorf("empty Hash Len: got %d, want 0", h.Len())
+	}
+	h.Set("b", 2)
+	h.Set("a", 1)
+	h.Set("c", 3)
+	if got := h.Keys(); !equalStrings(got, []string{"b", "a", "c"}) {
+		t.Errorf("Keys insertion order: got %v, want [b a c]", got)
+	}
+	// Updating an existing key preserves its position.
+	h.Set("a", 99)
+	if got := h.Keys(); !equalStrings(got, []string{"b", "a", "c"}) {
+		t.Errorf("Keys after re-Set: got %v, want [b a c]", got)
+	}
+	if v, ok := h.Get("a"); !ok || v.(int) != 99 {
+		t.Errorf("Get(a): got (%v, %v), want (99, true)", v, ok)
+	}
+	if _, ok := h.Get("missing"); ok {
+		t.Errorf("Get(missing): got ok=true, want false")
+	}
+	// Delete removes from both the map and the key order.
+	if !h.Delete("b") {
+		t.Errorf("Delete(b): got false, want true")
+	}
+	if got := h.Keys(); !equalStrings(got, []string{"a", "c"}) {
+		t.Errorf("Keys after Delete(b): got %v, want [a c]", got)
+	}
+	if h.Delete("missing") {
+		t.Errorf("Delete(missing): got true, want false")
+	}
+
+	// Collection truthiness via CoerceBool.
+	empty := NewHash(0)
+	if CoerceBool(empty) {
+		t.Errorf("CoerceBool(empty Hash): got true, want false")
+	}
+	if !CoerceBool(h) {
+		t.Errorf("CoerceBool(populated Hash): got false, want true")
+	}
+
+	// IsMap/IsIterable/Len.
+	if !IsMap(h) {
+		t.Errorf("IsMap(*Hash): got false, want true")
+	}
+	if !IsIterable(h) {
+		t.Errorf("IsIterable(*Hash): got false, want true")
+	}
+	if n, err := Len(h); err != nil || n != 2 {
+		t.Errorf("Len(*Hash): got (%d, %v), want (2, nil)", n, err)
+	}
+
+	// Iterate preserves insertion order and populates Loop.
+	var seen []string
+	var lastLoop Loop
+	_, _ = Iterate(h, func(k, v Value, l Loop) (bool, error) {
+		seen = append(seen, k.(string))
+		lastLoop = l
+		return false, nil
+	})
+	if !equalStrings(seen, []string{"a", "c"}) {
+		t.Errorf("Iterate order: got %v, want [a c]", seen)
+	}
+	if lastLoop.Length != 2 {
+		t.Errorf("Loop.Length after iteration: got %d, want 2", lastLoop.Length)
+	}
+
+	// GetAttr on *Hash.
+	if got, err := GetAttr(h, "c"); err != nil || got.(int) != 3 {
+		t.Errorf("GetAttr(*Hash, c): got (%v, %v), want (3, nil)", got, err)
+	}
+	if _, err := GetAttr(h, "missing"); err == nil {
+		t.Errorf("GetAttr(*Hash, missing): got nil err, want error")
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 func TestIsIterable(t *testing.T) {
 	ts := []struct {
 		name     string


### PR DESCRIPTION
Grab a coffee, this is a big one. I don't think I can split in multiple commits/PRs.

## Summary

Make hash literals (`{'a': 1, 'b': 2}`) iterate in insertion order, matching PHP-Twig. Today they iterate in a random Go-runtime order because stick evaluates them to a `map[string]stick.Value` and walks them via `reflect.MapKeys()`.

Repro the current behavior:

```twig
{% set m = {"b": 2, "a": 1, "c": 3} %}{% for k,v in m %}{{k}}={{v}};{% endfor %}
```

PHP-Twig: `b=2;a=1;c=3;`. Stick before this PR: random. With this PR: `b=2;a=1;c=3;`.

## Design

New `stick.Hash` type — an insertion-order-preserving `string → Value` map:

```go
type Hash struct {
    order []string
    vals  map[string]Value
}
```

with `NewHash`, `Set`, `Get`, `Has`, `Delete`, `Len`, `Keys` methods. `Set` appends to `order` on first insert and updates in place on a repeated key (position preserved).

Wired in:

- **`exec.go`** — the `*parse.HashExpr` case builds a `*Hash` instead of `make(map[string]Value)`. `{% include … with hash_literal %}` now type-switches on both `map[string]Value` and `*Hash` so the `with` clause works either way.
- **`value.go`** — `Iterate`, `Len`, `IsMap`, `IsIterable`, `GetAttr`, `CoerceBool` each have a `*Hash` case before the reflect fallback. Ordered iteration is the default for any value stick itself produces.
- **`twig/filter/filter.go`** — `filterMerge` preserves order by returning a `*Hash` when either input is already a `*Hash`; the existing `map+map → map` path is preserved for callers that type-assert. `filterReverse` builds a reversed `*Hash`. `filterKeys` returns a `*Hash`'s keys in insertion order (not sorted, unlike the existing Go-map path).

User-supplied context (`map[string]Value`) keeps its existing unordered semantics — the change is scoped to values stick produces internally.

## Test plan

- [x] `value_test.go` — unit tests for `*Hash` construction, `Set` (insert vs update), `Keys` order, `Delete` (both from map and order slice), `Get` hit/miss, `Len`, `IsMap`, `IsIterable`, `Iterate` (insertion order), `CoerceBool` (empty → false, non-empty → true), `GetAttr`.
- [x] `exec_test.go` — integration case: `{"b":2,"a":1,"c":3}` iterates as `b=2;a=1;c=3;`.
- [x] `twig/ordered_hash_test.go` — end-to-end cases covering the real-world accumulator idiom (`for k in keys|sort ... out|merge(...)` loop), `|reverse` on a hash literal, `|keys` insertion-order, and a regression test confirming user-supplied `map[string]Value` context merged with another map still works.
- [x] `go test ./...`, `go vet ./...`, `goimports -d -e .` all clean.

## Backward compatibility

- Callers passing `map[string]stick.Value` as template context: no change.
- Callers merging two plain Go maps via `|merge`: result stays a plain Go map.
- Callers type-asserting `.(map[string]Value)` on the result of a *hash-literal-in-template* expression: **affected**. They now get `*Hash`. None exist in stick itself; downstream consumers need to handle both.
- The `keys` filter on a `*Hash` returns insertion order; on a plain Go map it keeps the existing alphabetically-sorted behavior.

## Out of scope

- `stick.Equal` / `stick.Contains` for `*Hash`. Both are acknowledged stop-gaps (`TODO` comment on `Equal`) and coerce to string before comparing, so they still produce consistent results for `*Hash` via `CoerceString` fallback. Revisit when those functions are rewritten.
- `filterSort` producing a `*Hash` from a map input. PHP-Twig's `sort` returns a sequence, not a hash — matches current stick behavior.
- Teaching user-supplied context maps to preserve order. Users who want ordered context can construct a `*Hash` directly via `stick.NewHash`.
