### PR TITLE
exec: honor top-level set in child (extending) templates

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -362,6 +362,11 @@ func (s *state) walkChild(node parse.Node) error {
 		}
 	case *parse.UseNode:
 		return s.walkUseNode(node)
+	case *parse.SetNode:
+		// {% set %} at the top level of a child (extending) template:
+		// Twig spec says these run and are visible in blocks. Execute in
+		// the current scope so the parent walk finds the value.
+		return s.walkSetNode(node)
 	default:
 		// No need to handle other nodes. This function only populates blocks from a
 		// referenced template (in a use statement) and does not actually execute anything.

--- a/exec_test.go
+++ b/exec_test.go
@@ -123,6 +123,21 @@ var tests = []execTest{
 		expect("Hello, World!"),
 	),
 	newExecTest(
+		"Child top-level set visible in overriding block",
+		`{% extends 'BEFORE[{% block body %}DEFAULT{% endblock %}]AFTER' %}{% set x = 'hello' %}{% block body %}{{ x }}{% endblock %}`,
+		expect("BEFORE[hello]AFTER"),
+	),
+	newExecTest(
+		"Child top-level set visible in inherited parent block",
+		`{% extends '{% block body %}{{ x|default("none") }}{% endblock %}' %}{% set x = 'hello' %}`,
+		expect("hello"),
+	),
+	newExecTest(
+		"Child top-level sets run in order",
+		`{% extends '{% block body %}{{ a }}-{{ b }}{% endblock %}' %}{% set a = 'first' %}{% set b = a ~ '/second' %}`,
+		expect("first-first/second"),
+	),
+	newExecTest(
 		"Set statement",
 		`{% set val = 'a value' %}{{ val }}`,
 		expect("a value"),


### PR DESCRIPTION
## Summary

Honor top-level `{% set %}` in a child (extending) template, per the Twig 3.x [`extends` spec](https://twig.symfony.com/doc/3.x/tags/extends.html):

> anywhere outside a block tag, you can still use `{% set %}` tags. The set variables are available in any block of the child template.

Before: `exec.go:walkChild` only dispatched `*parse.BodyNode` (recursion) and `*parse.UseNode`. Any `{% set %}` at the child's top level fell into the `default` arm with a comment saying "No need to handle other nodes" and was silently dropped. Child blocks — and parent blocks inherited without override — saw the name as undefined.

After: add a `*parse.SetNode` case that delegates to the existing `walkSetNode`. The set executes against the current (top-level) scope *before* the parent root is walked, so blocks on either side of the extends find the value.

## Background

Templates that front-load value extraction above the block that uses them — a common Pico-era Twig idiom — broke silently. For example:

```twig
{% extends 'layout' %}
{% set q = url_param('q') %}
{% block content %}
  {% if q %}Searching for {{ q }}{% endif %}
{% endblock %}
```

Stick saw `q` as undefined inside the block, so the `{% if q %}` branch never fired.

## Test plan

- [x] Three new cases in `exec_test.go`'s `tests` table covering:
  - Child top-level `set` visible in an overriding block.
  - Child top-level `set` visible in a parent block inherited without override.
  - Multiple top-level `set`s run in order and can reference each other.
- [x] `go test ./...`, `go vet ./...`, `goimports -d -e .` all clean.

## Out of scope

- `{% import %}`, `{% from %}`, `{% macro %}` at the child top level. The Twig spec also permits these, but their walkers interact with macro-registration state (`s.localMacros`, `s.macros`) and merit their own review. Follow-up PRs.
- Error handling for disallowed node types (e.g. `{% for %}` at child top level). Twig errors on those; stick currently silently ignores them. Separate quality-of-life improvement.
