### PR TITLE
value: make Contains handle string haystacks via substring match

### DIFF
--- a/exec_test.go
+++ b/exec_test.go
@@ -108,6 +108,11 @@ var tests = []execTest{
 		expect(`45 - 4 - 1 - 1 - 1`),
 	),
 	newExecTest("In and not in", `{{ 5 in set and 4 not in set }}`, expect(`1`), withContext(map[string]Value{"set": []int{5, 10}})),
+	newExecTest(
+		"In operator on string does substring match",
+		`{% if 'bar' in 'foo bar baz' %}yes{% else %}no{% endif %}`,
+		expect("yes"),
+	),
 	newExecTest("Function call", `{{ multiply(num, 5) }}`, expect(`50`), withContext(map[string]Value{"num": 10})),
 	newExecTest("Filter call", `Welcome, {{ name }}`, expect(`Welcome, `)),
 	newExecTest("Filter call", `Welcome, {{ name|default('User') }}`, expect(`Welcome, User`), withContext(map[string]Value{"name": nil})),

--- a/value.go
+++ b/value.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"strings"
 
 	"github.com/shopspring/decimal"
 )
@@ -414,7 +415,14 @@ func Equal(left Value, right Value) bool {
 }
 
 // Contains returns true if the haystack Value contains needle.
+//
+// For string haystacks the check is substring-based (matching PHP-Twig's
+// `in` operator semantics for strings). The needle is coerced to string.
+// For slice/array/map haystacks the check iterates and compares elements.
 func Contains(haystack Value, needle Value) (bool, error) {
+	if hs, ok := haystack.(string); ok {
+		return strings.Contains(hs, CoerceString(needle)), nil
+	}
 	res := false
 	_, err := Iterate(haystack, func(k Value, v Value, l Loop) (bool, error) {
 		if Equal(v, needle) {

--- a/value_test.go
+++ b/value_test.go
@@ -321,6 +321,33 @@ func TestIterate(t *testing.T) {
 	}
 }
 
+func TestContains(t *testing.T) {
+	ts := []struct {
+		name    string
+		hay     Value
+		needle  Value
+		want    bool
+		wantErr bool
+	}{
+		{"string haystack match", "foo bar baz", "bar", true, false},
+		{"string haystack miss", "foo bar baz", "qux", false, false},
+		{"string haystack numeric needle", "5 apples", 5, true, false},
+		{"string haystack empty needle", "anything", "", true, false},
+		{"slice haystack match", []int{1, 2, 3}, 2, true, false},
+		{"slice haystack miss", []int{1, 2, 3}, 99, false, false},
+		{"map haystack match by value", map[string]int{"a": 1, "b": 2}, 2, true, false},
+	}
+	for _, tc := range ts {
+		got, err := Contains(tc.hay, tc.needle)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("%s: err=%v wantErr=%v", tc.name, err, tc.wantErr)
+		}
+		if got != tc.want {
+			t.Errorf("%s: got %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
 func TestIterate_breakSlice(t *testing.T) {
 	vals := []string{"hello", "world", "!"}
 	res := []string{}


### PR DESCRIPTION
## Summary

Make `stick.Contains` (the backend for the `in` operator) handle string haystacks via substring match, matching [Twig's `in`-on-string](https://twig.symfony.com/doc/3.x/templates.html#containment-operator) semantics.

Before: `Contains` delegated straight to `Iterate`, whose string arm returns an error. Any template using `{% if needle in str %}` crashed at runtime:

```
stick: unable to iterate over string "foo bar baz"
```

After: add an early return — if the haystack is a string, use `strings.Contains(haystack, CoerceString(needle))`. Non-string haystacks fall through to the existing iterate path with no behavior change.

PHP-Twig coerces the needle to string before comparing, so `{{ 5 in '5 apples' }}` → `true`. This PR matches that.

## Test plan

- [x] New `TestContains` in `value_test.go` covering string haystack (match / miss / numeric needle / empty needle), plus regression cases for slice and map haystacks.
- [x] New integration case in `exec_test.go` next to the existing `In and not in` test: `{% if 'bar' in 'foo bar baz' %}yes{% else %}no{% endif %}` → `yes`.
- [x] `go test ./...`, `go vet ./...`, `goimports -d -e .` all clean.

## Out of scope

- Numeric haystacks (`{{ 5 in 15 }}`) — PHP-Twig doesn't define this. Would need a shape decision if ever needed.
- Performance of iterate-based equality on large collections — stick's `Equal` still coerces both sides to strings; orthogonal to this PR.
- `starts with` / `ends with` tests — those live (or would live) in `twig/tests` as separate `Test` entries.
