### PR TITLE
twig: add range, cycle, random, attribute built-in functions

### DIFF
--- a/twig/builtin_functions_test.go
+++ b/twig/builtin_functions_test.go
@@ -6,6 +6,55 @@ import (
 	"github.com/tyler-sommer/stick"
 )
 
+// TestBuiltinRange covers range() across the int, char, and step
+// variants the Twig docs call out.
+func TestBuiltinRange(t *testing.T) {
+	cases := []struct {
+		name string
+		tpl  string
+		want string
+	}{
+		{"int asc", `{% for i in range(1, 3) %}{{ i }}-{% endfor %}`, "1-2-3-"},
+		{"int desc", `{% for i in range(3, 1) %}{{ i }}-{% endfor %}`, "3-2-1-"},
+		{"int with step", `{% for i in range(0, 6, 2) %}{{ i }};{% endfor %}`, "0;2;4;6;"},
+		{"chars", `{% for c in range('a', 'c') %}{{ c }}{% endfor %}`, "abc"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := mustRender(t, tc.tpl, nil); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBuiltinCycle covers the wrap-around behavior of cycle().
+func TestBuiltinCycle(t *testing.T) {
+	tpl := `{% for i in range(0, 5) %}{{ cycle(['x','y','z'], i) }}{% endfor %}`
+	if got := mustRender(t, tpl, nil); got != "xyzxyz" {
+		t.Errorf("cycle wrap: got %q, want %q", got, "xyzxyz")
+	}
+}
+
+// TestBuiltinAttribute covers dynamic attribute access via attribute().
+func TestBuiltinAttribute(t *testing.T) {
+	tpl := `{{ attribute(p, 'name') }}`
+	ctx := map[string]stick.Value{"p": map[string]stick.Value{"name": "Alice"}}
+	if got := mustRender(t, tpl, ctx); got != "Alice" {
+		t.Errorf("attribute: got %q, want Alice", got)
+	}
+}
+
+// TestBuiltinRandom asserts random() returns a value of the expected
+// shape, not a specific element (since output is unpredictable).
+func TestBuiltinRandom(t *testing.T) {
+	tpl := `{{ random([1, 2, 3]) }}`
+	got := mustRender(t, tpl, nil)
+	if got != "1" && got != "2" && got != "3" {
+		t.Errorf("random: got %q, want one of 1/2/3", got)
+	}
+}
+
 // TestBuiltinMaxMin exercises twig.New's Functions wiring end-to-end, so a
 // future change that accidentally drops fn.TwigFunctions fails here.
 func TestBuiltinMaxMin(t *testing.T) {

--- a/twig/fn/fn.go
+++ b/twig/fn/fn.go
@@ -2,15 +2,23 @@
 // the Twig 3.x built-in functions at https://twig.symfony.com/doc/3.x/functions/ .
 package fn // import "github.com/tyler-sommer/stick/twig/fn"
 
-import "github.com/tyler-sommer/stick"
+import (
+	"math/rand"
+
+	"github.com/tyler-sommer/stick"
+)
 
 // TwigFunctions returns PHP Twig 3.x's built-in function set. A fresh map
 // is returned on each call so callers can mutate it without affecting
 // others.
 func TwigFunctions() map[string]stick.Func {
 	return map[string]stick.Func{
-		"max": fnMax,
-		"min": fnMin,
+		"attribute": fnAttribute,
+		"cycle":     fnCycle,
+		"max":       fnMax,
+		"min":       fnMin,
+		"random":    fnRandom,
+		"range":     fnRange,
 	}
 }
 
@@ -59,4 +67,202 @@ func extremum(args []stick.Value, max bool) stick.Value {
 		}
 	}
 	return best
+}
+
+// fnRange returns a list containing an arithmetic progression between two
+// endpoints. Mirrors PHP-Twig's range():
+//
+//	range(0, 3)            → [0, 1, 2, 3]
+//	range(0, 6, 2)         → [0, 2, 4, 6]
+//	range(10, 1)           → [10, 9, …, 1]   (step defaults to -1 when low > high)
+//	range('a', 'c')        → ["a", "b", "c"]
+//
+// A step of 0 (or one whose sign disagrees with high-low) is normalised
+// to ±1 to avoid infinite loops.
+func fnRange(_ stick.Context, args ...stick.Value) stick.Value {
+	if len(args) < 2 {
+		return []stick.Value{}
+	}
+	if lo, ok := args[0].(string); ok {
+		if hi, ok2 := args[1].(string); ok2 {
+			loRunes, hiRunes := []rune(lo), []rune(hi)
+			if len(loRunes) == 1 && len(hiRunes) == 1 {
+				return runeRange(loRunes[0], hiRunes[0], rangeStep(args, 0))
+			}
+		}
+	}
+	return numRange(stick.CoerceNumber(args[0]), stick.CoerceNumber(args[1]), rangeStep(args, 0))
+}
+
+// rangeStep extracts an explicit step argument or returns 0 (caller
+// normalises by direction).
+func rangeStep(args []stick.Value, def float64) float64 {
+	if len(args) < 3 {
+		return def
+	}
+	return stick.CoerceNumber(args[2])
+}
+
+func numRange(lo, hi, step float64) stick.Value {
+	if step == 0 {
+		if lo <= hi {
+			step = 1
+		} else {
+			step = -1
+		}
+	}
+	// Reject misdirected steps (e.g. step=1 with lo>hi) by flipping
+	// sign — matches PHP's silent flip.
+	if (lo < hi && step < 0) || (lo > hi && step > 0) {
+		step = -step
+	}
+	out := []stick.Value{}
+	intMode := lo == float64(int64(lo)) && hi == float64(int64(hi)) && step == float64(int64(step))
+	if step > 0 {
+		for v := lo; v <= hi; v += step {
+			if intMode {
+				out = append(out, int(v))
+			} else {
+				out = append(out, v)
+			}
+		}
+	} else {
+		for v := lo; v >= hi; v += step {
+			if intMode {
+				out = append(out, int(v))
+			} else {
+				out = append(out, v)
+			}
+		}
+	}
+	return out
+}
+
+func runeRange(lo, hi rune, step float64) stick.Value {
+	istep := int(step)
+	if istep == 0 {
+		if lo <= hi {
+			istep = 1
+		} else {
+			istep = -1
+		}
+	}
+	if (lo < hi && istep < 0) || (lo > hi && istep > 0) {
+		istep = -istep
+	}
+	out := []stick.Value{}
+	if istep > 0 {
+		for r := lo; r <= hi; r += rune(istep) {
+			out = append(out, string(r))
+		}
+	} else {
+		for r := lo; r >= hi; r += rune(istep) {
+			out = append(out, string(r))
+		}
+	}
+	return out
+}
+
+// fnCycle returns the value at position % len(values) in the values list,
+// wrapping. Mirrors PHP-Twig's cycle().
+//
+//	cycle(['a', 'b', 'c'], 4)   → 'b'    (4 mod 3 = 1)
+//	cycle(['x', 'y'], -1)       → 'y'    (negative positions wrap)
+//	cycle([], anything)         → nil
+func fnCycle(_ stick.Context, args ...stick.Value) stick.Value {
+	if len(args) < 2 || !stick.IsIterable(args[0]) {
+		return nil
+	}
+	n, _ := stick.Len(args[0])
+	if n == 0 {
+		return nil
+	}
+	idx := int(stick.CoerceNumber(args[1])) % n
+	if idx < 0 {
+		idx += n
+	}
+	var out stick.Value
+	_, _ = stick.Iterate(args[0], func(_, v stick.Value, l stick.Loop) (bool, error) {
+		if l.Index0 == idx {
+			out = v
+			return true, nil
+		}
+		return false, nil
+	})
+	return out
+}
+
+// fnRandom mirrors PHP-Twig's random() per the docs:
+//
+//	random()           → a random non-negative int (math/rand)
+//	random(N)          → a random int in [0, N] (inclusive)
+//	random("abc")      → a random single character
+//	random([x,y,z])    → a random element of the iterable
+//
+// Uses math/rand — Twig's random() is a templating helper, not a
+// cryptographic primitive. Go 1.20+ auto-seeds the global source.
+func fnRandom(_ stick.Context, args ...stick.Value) stick.Value {
+	if len(args) == 0 {
+		return rand.Int63()
+	}
+	v := args[0]
+	switch x := v.(type) {
+	case string:
+		runes := []rune(x)
+		if len(runes) == 0 {
+			return ""
+		}
+		return string(runes[rand.Intn(len(runes))])
+	case int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64,
+		float32, float64:
+		max := int64(stick.CoerceNumber(v))
+		if max <= 0 {
+			return int64(0)
+		}
+		return rand.Int63n(max + 1)
+	}
+	if stick.IsIterable(v) {
+		n, _ := stick.Len(v)
+		if n == 0 {
+			return nil
+		}
+		idx := rand.Intn(n)
+		var out stick.Value
+		_, _ = stick.Iterate(v, func(_, vv stick.Value, l stick.Loop) (bool, error) {
+			if l.Index0 == idx {
+				out = vv
+				return true, nil
+			}
+			return false, nil
+		})
+		return out
+	}
+	return v
+}
+
+// fnAttribute does a dynamic attribute / method lookup, matching
+// PHP-Twig's attribute() function — useful when the attribute name is
+// computed at template time:
+//
+//	{{ attribute(person, attr_name) }}
+//	{{ attribute(person, "greet", ["Bob"]) }}
+//
+// Returns nil if the attribute can't be resolved (matches PHP-Twig's
+// behaviour of returning null on missing attribute).
+func fnAttribute(_ stick.Context, args ...stick.Value) stick.Value {
+	if len(args) < 2 {
+		return nil
+	}
+	var callArgs []stick.Value
+	if len(args) >= 3 {
+		if l, ok := args[2].([]stick.Value); ok {
+			callArgs = l
+		}
+	}
+	v, err := stick.GetAttr(args[0], args[1], callArgs...)
+	if err != nil {
+		return nil
+	}
+	return v
 }

--- a/twig/fn/fn_test.go
+++ b/twig/fn/fn_test.go
@@ -1,6 +1,7 @@
 package fn
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/tyler-sommer/stick"
@@ -34,9 +35,140 @@ func TestMaxMin(t *testing.T) {
 
 func TestTwigFunctionsRegistration(t *testing.T) {
 	fns := TwigFunctions()
-	for _, name := range []string{"max", "min"} {
+	for _, name := range []string{"max", "min", "range", "cycle", "random", "attribute"} {
 		if _, ok := fns[name]; !ok {
 			t.Errorf("TwigFunctions missing %q", name)
+		}
+	}
+}
+
+// equalRange compares the two slices element-by-element, normalising int
+// vs int-typed-as-int to avoid spurious mismatches from %T differences.
+func equalRange(a, b []stick.Value) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestRange(t *testing.T) {
+	ts := []struct {
+		name string
+		args []stick.Value
+		want []stick.Value
+	}{
+		{"int asc", []stick.Value{1, 5}, []stick.Value{1, 2, 3, 4, 5}},
+		{"int desc default step", []stick.Value{5, 1}, []stick.Value{5, 4, 3, 2, 1}},
+		{"int with step", []stick.Value{0, 6, 2}, []stick.Value{0, 2, 4, 6}},
+		{"int negative range", []stick.Value{-2, 2}, []stick.Value{-2, -1, 0, 1, 2}},
+		{"single", []stick.Value{3, 3}, []stick.Value{3}},
+		{"misdirected step flips", []stick.Value{5, 1, 1}, []stick.Value{5, 4, 3, 2, 1}},
+		{"too few args", []stick.Value{1}, []stick.Value{}},
+		{"chars asc", []stick.Value{"a", "d"}, []stick.Value{"a", "b", "c", "d"}},
+		{"chars desc", []stick.Value{"c", "a"}, []stick.Value{"c", "b", "a"}},
+	}
+	for _, tc := range ts {
+		got := fnRange(nil, tc.args...).([]stick.Value)
+		if !equalRange(got, tc.want) {
+			t.Errorf("%s: got %v, want %v", tc.name, got, tc.want)
+		}
+	}
+
+	// Float input — when either endpoint isn't integer, results are
+	// floats throughout.
+	got := fnRange(nil, 0.5, 2.5, 1.0).([]stick.Value)
+	if len(got) != 3 || got[0] != 0.5 || got[2] != 2.5 {
+		t.Errorf("float range: got %v", got)
+	}
+}
+
+func TestCycle(t *testing.T) {
+	values := []stick.Value{"a", "b", "c"}
+	ts := []struct {
+		name string
+		args []stick.Value
+		want stick.Value
+	}{
+		{"index 0", []stick.Value{values, 0}, "a"},
+		{"index 4 wraps", []stick.Value{values, 4}, "b"},
+		{"index -1 wraps", []stick.Value{values, -1}, "c"},
+		{"index -4 wraps", []stick.Value{values, -4}, "c"},
+		{"empty list", []stick.Value{[]stick.Value{}, 0}, nil},
+		{"too few args", []stick.Value{values}, nil},
+		{"non-iterable", []stick.Value{42, 0}, nil},
+	}
+	for _, tc := range ts {
+		got := fnCycle(nil, tc.args...)
+		if got != tc.want {
+			t.Errorf("%s: got %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestRandom(t *testing.T) {
+	// random() with no args: returns an int63. Just make sure it doesn't
+	// panic and produces something representable as int64.
+	for i := 0; i < 10; i++ {
+		v := fnRandom(nil)
+		if _, ok := v.(int64); !ok {
+			t.Errorf("random() empty: got %T, want int64", v)
+		}
+	}
+
+	// random(N): result must be in [0, N].
+	for i := 0; i < 100; i++ {
+		v := fnRandom(nil, 5).(int64)
+		if v < 0 || v > 5 {
+			t.Errorf("random(5): got %d, want [0..5]", v)
+		}
+	}
+
+	// random("abcde"): result must be a single character from the input.
+	for i := 0; i < 50; i++ {
+		s := fnRandom(nil, "abcde").(string)
+		if len(s) != 1 || !strings.ContainsRune("abcde", rune(s[0])) {
+			t.Errorf(`random("abcde"): got %q`, s)
+		}
+	}
+
+	// random(iterable): returns one of the elements.
+	for i := 0; i < 50; i++ {
+		v := fnRandom(nil, []stick.Value{"x", "y", "z"})
+		s, _ := v.(string)
+		if s != "x" && s != "y" && s != "z" {
+			t.Errorf("random(slice): got %v", v)
+		}
+	}
+
+	// Empty inputs.
+	if v := fnRandom(nil, ""); v != "" {
+		t.Errorf(`random(""): got %v`, v)
+	}
+	if v := fnRandom(nil, []stick.Value{}); v != nil {
+		t.Errorf("random([]): got %v", v)
+	}
+}
+
+func TestAttribute(t *testing.T) {
+	m := map[string]stick.Value{"name": "Alice", "age": 30}
+	cases := []struct {
+		name string
+		args []stick.Value
+		want stick.Value
+	}{
+		{"map key", []stick.Value{m, "name"}, "Alice"},
+		{"map missing key", []stick.Value{m, "nope"}, nil},
+		{"too few args", []stick.Value{m}, nil},
+	}
+	for _, tc := range cases {
+		got := fnAttribute(nil, tc.args...)
+		if got != tc.want {
+			t.Errorf("%s: got %v, want %v", tc.name, got, tc.want)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Add four PHP-Twig built-in functions to the `twig/fn` package introduced in #75. Each is documented in the PHP-Twig 3.x function index and behaves per the linked spec.

| Function | Spec | Notes |
|---|---|---|
| `range(low, high, step=1)` | [docs](https://twig.symfony.com/doc/3.x/functions/range.html) | Numeric and single-character endpoints; default step is `±1` based on direction; misdirected steps flip silently to avoid infinite loops. |
| `cycle(values, position)` | [docs](https://twig.symfony.com/doc/3.x/functions/cycle.html) | `values[position % len(values)]`; negative positions wrap. |
| `random(values?)` | [docs](https://twig.symfony.com/doc/3.x/functions/random.html) | No-arg → random int63; int → `[0, N]` inclusive; string → single character; iterable → element. Uses `math/rand` (templating helper, not a security primitive); Go 1.20+ auto-seeds the global source. |
| `attribute(obj, name, args=[])` | [docs](https://twig.symfony.com/doc/3.x/functions/attribute.html) | Direct call to `stick.GetAttr`; nil on missing. |

Same-package batch follows the precedent set by #72.

## Test plan

- [x] Per-function unit tests in `twig/fn/fn_test.go` covering edge cases (empty input, missing args, asc/desc, wrap-around, character ranges).
- [x] Integration cases in `twig/builtin_functions_test.go` exercising `twig.New` end-to-end (so the `fn.TwigFunctions()` wiring stays covered).
- [x] `go test ./...`, `go vet ./...`, `goimports -d -e .` all clean.

## Out of scope

- `date(...)` function — the `|date` filter at `twig/filter/filter.go:filterDate` already handles `time.Time`; adding a function form needs a small "now"/parse helper plus timezone semantics. Defer.
- `dump(...)` — needs a debug-output hook on `*stick.Env` first.
- `constant(name)` — no clean Go mapping for PHP class constants.
- The lexicographic-compare extension to `max`/`min` lives in a separate PR so each is reviewable on its own.
