### PR TITLE
twig: max / min compare strings lexicographically

### DIFF
--- a/twig/builtin_functions_test.go
+++ b/twig/builtin_functions_test.go
@@ -23,6 +23,8 @@ func TestBuiltinMaxMin(t *testing.T) {
 			`{{ max(counts) }}`, map[string]stick.Value{
 				"counts": map[string]stick.Value{"a": 2, "b": 7, "c": 5},
 			}, "7"},
+		{"max strings lexicographic", `{{ max('apple', 'banana') }}`, nil, "banana"},
+		{"min strings lexicographic", `{{ min('banana', 'apple') }}`, nil, "apple"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/twig/fn/fn.go
+++ b/twig/fn/fn.go
@@ -2,7 +2,11 @@
 // the Twig 3.x built-in functions at https://twig.symfony.com/doc/3.x/functions/ .
 package fn // import "github.com/tyler-sommer/stick/twig/fn"
 
-import "github.com/tyler-sommer/stick"
+import (
+	"strings"
+
+	"github.com/tyler-sommer/stick"
+)
 
 // TwigFunctions returns PHP Twig 3.x's built-in function set. A fresh map
 // is returned on each call so callers can mutate it without affecting
@@ -16,15 +20,17 @@ func TwigFunctions() map[string]stick.Func {
 
 // fnMax returns the largest of its arguments. Mirrors PHP-Twig's max():
 //
-//	max(1, 2, 3)          → 3
-//	max([1, 3, 2])        → 3
-//	max({'a':1,'b':3})    → 3 (hash values)
-//	max()                 → nil
+//	max(1, 2, 3)             → 3
+//	max([1, 3, 2])           → 3
+//	max({'a':1,'b':3})       → 3 (hash values)
+//	max('apple', 'banana')   → 'banana' (lexicographic when all-strings)
+//	max(2, '10')             → '10' (mixed: numeric coercion path)
+//	max()                    → nil
 //
-// Numeric comparison uses stick.CoerceNumber, matching PHP's loose-typing
-// behavior. String comparison is not implemented here — both sides coerce
-// to 0 and the first argument wins. Hashtagueule doesn't exercise that
-// path; add it if a real theme needs it.
+// All-string operand sequences are compared lexicographically via
+// strings.Compare. Any non-string operand triggers fallback to numeric
+// comparison via stick.CoerceNumber, matching PHP's loose-typing
+// preference for the numeric interpretation of mixed inputs.
 func fnMax(_ stick.Context, args ...stick.Value) stick.Value {
 	return extremum(args, true)
 }
@@ -37,14 +43,25 @@ func fnMin(_ stick.Context, args ...stick.Value) stick.Value {
 func extremum(args []stick.Value, max bool) stick.Value {
 	var best stick.Value
 	seen := false
+	allStrings := true
 	feed := func(v stick.Value) {
+		if _, isStr := v.(string); !isStr {
+			allStrings = false
+		}
 		if !seen {
 			best, seen = v, true
 			return
 		}
-		cur := stick.CoerceNumber(v)
-		top := stick.CoerceNumber(best)
-		if (max && cur > top) || (!max && cur < top) {
+		var better bool
+		if allStrings {
+			cmp := strings.Compare(v.(string), best.(string))
+			better = (max && cmp > 0) || (!max && cmp < 0)
+		} else {
+			cur := stick.CoerceNumber(v)
+			top := stick.CoerceNumber(best)
+			better = (max && cur > top) || (!max && cur < top)
+		}
+		if better {
 			best = v
 		}
 	}

--- a/twig/fn/fn_test.go
+++ b/twig/fn/fn_test.go
@@ -23,6 +23,14 @@ func TestMaxMin(t *testing.T) {
 		{"min no args", fnMin, []stick.Value{}, nil},
 		{"max float beats int", fnMax, []stick.Value{2, 2.5}, 2.5},
 		{"min negative", fnMin, []stick.Value{-5, -3, -10}, -10},
+		// Lexicographic compare when every operand is a string.
+		{"max strings", fnMax, []stick.Value{"apple", "banana", "cherry"}, "cherry"},
+		{"min strings", fnMin, []stick.Value{"banana", "apple", "cherry"}, "apple"},
+		{"max string slice", fnMax, []stick.Value{[]stick.Value{"z", "a", "m"}}, "z"},
+		{"min single string", fnMin, []stick.Value{"only"}, "only"},
+		// Mixed type: any non-string flips to numeric comparison.
+		{"max mixed string and int", fnMax, []stick.Value{2, "10"}, "10"},
+		{"min mixed", fnMin, []stick.Value{"5", 1}, 1},
 	}
 	for _, tc := range ts {
 		got := tc.fn(nil, tc.args...)


### PR DESCRIPTION
## Summary

Make `max` / `min` compare strings lexicographically, matching PHP-Twig.

Before: `extremum` always went through `stick.CoerceNumber`, which collapses non-numeric strings to `0`. So `max("banana", "apple")` returned `"banana"` only by accident (first arg wins on a tie at zero); reversing arg order would return `"apple"`.

After: when every operand seen is a `string`, compare via `strings.Compare`. The first non-string operand flips the path back to numeric — that mirrors PHP's loose-typing preference for numeric interpretation in mixed-type comparisons (`max(2, "10")` → `"10"`).

## Test plan

- [x] New cases in `TestMaxMin`: all-string vs all-string, single-string slice, mixed-type fallback both directions.
- [x] Two integration cases in `twig/builtin_functions_test.go` so `twig.New` wiring stays covered.
- [x] Existing numeric `TestMaxMin` cases still pass.
- [x] `go test ./...`, `go vet ./...`, `goimports -d -e .` all clean.

## Out of scope

- A general "loose compare" matching PHP `<`/`>` for arbitrary mixed types (e.g. numeric strings vs ints across both edges of the comparison). The all-strings vs anything-else split covers the practical cases templates use; PHP's full ladder is fiddly and rarely exercised.
